### PR TITLE
ipa-replica-install: make sure that certmonger picks the right master

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -23,7 +23,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f27
           name: freeipa/ci-master-f27
-          version: 1.0.2
+          version: 1.0.3
         timeout: 1800
         topology: *build
 

--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -62,3 +62,123 @@ jobs:
         template: *ci-master-f27
         timeout: 3600
         topology: *master_1repl
+
+  fedora-27/test_topologies:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_topologies.py
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-27/test_sudo:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_sudo.py
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-27/test_kerberos_flags:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_kerberos_flags.py
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-27/test_http_kdc_proxy:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_http_kdc_proxy.py
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-27/test_forced_client_enrolment:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_forced_client_reenrollment.py
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl_1client
+
+  fedora-27/test_advise:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_advise.py
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-27/test_testconfig:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_testconfig.py
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-27/test_service_permissions:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_service_permissions.py
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-27/test_netgroup:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_netgroup.py
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-27/test_vault:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_vault.py
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl

--- a/.test_runner_config.yaml
+++ b/.test_runner_config.yaml
@@ -60,7 +60,7 @@ steps:
   - dnf install -y npm
   - cd ${container_working_dir}/install/ui/js/libs && make
   - cd ${container_working_dir}/install/ui && npm install
-  - cd ${container_working_dir}/install/ui && node_modules/grunt/bin/grunt --verbose qunit
+  - cd ${container_working_dir}/install/ui && node_modules/grunt/bin/grunt --verbose test
   tox:
   # just run one pylint and one Python 3 target (time/coverage trade-off)
   - tox -e py27,py36,pypi,pylint3

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,8 @@
 ACLOCAL_AMFLAGS = -I m4
 
 if ENABLE_SERVER
-    SERVER_SUBDIRS = daemons init install ipaserver
+    IPASERVER_SUBDIRS = ipaserver
+    SERVER_SUBDIRS = daemons init install
 endif
 
 if WITH_IPATESTS
@@ -9,9 +10,9 @@ if WITH_IPATESTS
 endif
 
 IPACLIENT_SUBDIRS = ipaclient ipalib ipaplatform ipapython
+PYTHON_SUBDIRS = $(IPACLIENT_SUBDIRS) $(IPATESTS_SUBDIRS) $(IPASERVER_SUBDIRS)
 IPA_PLACEHOLDERS = freeipa ipa ipaserver ipatests
-SUBDIRS = asn1 util client contrib po pypi \
-	$(IPACLIENT_SUBDIRS) $(IPATESTS_SUBDIRS) $(SERVER_SUBDIRS)
+SUBDIRS = asn1 util client contrib po pypi $(PYTHON_SUBDIRS) $(SERVER_SUBDIRS)
 
 GENERATED_PYTHON_FILES = \
 	$(top_builddir)/ipaplatform/override.py \
@@ -357,6 +358,12 @@ pypi_packages: $(WHEELPYPIDIR) .wheelconstraints
 	done
 	@echo -e "\n\nTo upload packages to PyPI, run:\n"
 	@echo -e "    twine upload $(WHEELPYPIDIR)/*-$(VERSION)-py2.py3-none-any.whl\n"
+
+.PHONY: python_install
+python_install:
+	for dir in $(PYTHON_SUBDIRS); do \
+	    $(MAKE) $(AM_MAKEFLAGS) -C $${dir} install || exit 1; \
+	done
 
 .PHONY:
 strip-po:

--- a/configure.ac
+++ b/configure.ac
@@ -100,27 +100,28 @@ PKG_CHECK_MODULES([CRYPTO], [libcrypto])
 
 dnl ---------------------------------------------------------------------------
 dnl - Check for Python
-dnl ---------------------------------------------------------------------------
-
-AC_MSG_NOTICE([Checking for Python])
-have_python=no
-AM_PATH_PYTHON(2.7)
-
-if test "x$PYTHON" = "x" ; then
-  AC_MSG_ERROR([Python not found])
-fi
-
-dnl ---------------------------------------------------------------------------
 dnl - Check for Python 2/3 for devcheck
 dnl ---------------------------------------------------------------------------
 
+AC_MSG_NOTICE([Checking for Python 3])
+AC_PATH_PROG(PYTHON3, python3)
+AC_SUBST([PYTHON3])
+AM_CONDITIONAL([WITH_PYTHON3], [test "x${PYTHON3}" != "x"])
+
+AC_MSG_NOTICE([Checking for Python 2])
 AC_PATH_PROG(PYTHON2, python2)
 AC_SUBST([PYTHON2])
 AM_CONDITIONAL([WITH_PYTHON2], [test "x${PYTHON2}" != "x"])
 
-AC_PATH_PROG(PYTHON3, python3)
-AC_SUBST([PYTHON3])
-AM_CONDITIONAL([WITH_PYTHON3], [test "x${PYTHON3}" != "x"])
+if test \( "x${PYTHON3}" = "x" -o "x${PYTHON}" != "x" \); then
+    dnl Python 3 is not available *or* user has set PYTHON variable.
+    dnl Accept Python >= 2.7 as default Python. We also accept any Python 3
+    dnl version from PYTHON environment variable.
+    AM_PATH_PYTHON(2.7)
+elif test "x${PYTHON3}" != "x"; then
+    dnl Found Python 3, but no user override. Use Python >= 3.6 as default.
+    AM_PATH_PYTHON(3.6)
+fi
 
 dnl ---------------------------------------------------------------------------
 dnl - Check for cmocka unit test framework http://cmocka.cryptomilk.org/
@@ -590,7 +591,9 @@ echo "
         source code location:     ${srcdir}
         compiler:                 ${CC}
         cflags:                   ${CFLAGS}
-        Python:                   ${PYTHON}
+        Default Python:           ${PYTHON} (${PYTHON_VERSION})
+        Python 2:                 ${PYTHON2}
+        Python 3:                 ${PYTHON3}
         pylint:                   ${PYLINT}
         jslint:                   ${JSLINT}
         LDAP libs:                ${LDAP_LIBS}

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -990,16 +990,7 @@ make %{?_smp_mflags} check VERBOSE=yes LIBDIR=%{_libdir}
 # will overwrite /usr/bin/ipa and other scripts with variants using
 # python2 shebang.
 pushd %{_builddir}/freeipa-%{version}-python3
-(cd ipaclient && %make_install)
-(cd ipalib && %make_install)
-(cd ipaplatform && %make_install)
-(cd ipapython && %make_install)
-%if ! %{ONLY_CLIENT}
-(cd ipaserver && %make_install)
-%endif # ONLY_CLIENT
-%if 0%{?with_ipatests}
-(cd ipatests && %make_install)
-%endif # with_ipatests
+%{__make} python_install DESTDIR=%{?buildroot} INSTALL="%{__install} -p"
 popd
 
 %if 0%{?with_ipatests}

--- a/install/share/ipa-pki-proxy.conf.template
+++ b/install/share/ipa-pki-proxy.conf.template
@@ -1,4 +1,4 @@
-# VERSION 12 - DO NOT REMOVE THIS LINE
+# VERSION 13 - DO NOT REMOVE THIS LINE
 
 ProxyRequests Off
 
@@ -43,4 +43,4 @@ ProxyRequests Off
 </LocationMatch>
 
 # Only enable this on servers that are not generating a CRL
-${CLONE}RewriteRule ^/ipa/crl/MasterCRL.bin https://$FQDN/ca/ee/ca/getCRL?op=getCRL&crlIssuingPoint=MasterCRL [L,R=301,NC]
+${CLONE}RewriteRule ^/ipa/crl/MasterCRL.bin http://$FQDN/ca/ee/ca/getCRL?op=getCRL&crlIssuingPoint=MasterCRL [L,R=301,NC]

--- a/install/share/ipa.conf.template
+++ b/install/share/ipa.conf.template
@@ -1,5 +1,5 @@
 #
-# VERSION 27 - DO NOT REMOVE THIS LINE
+# VERSION 28 - DO NOT REMOVE THIS LINE
 #
 # This file may be overwritten on upgrades.
 #
@@ -34,12 +34,6 @@ AddType application/x-font-ttf          ttf
 AddOutputFilterByType DEFLATE text/html text/plain text/xml \
  application/javascript application/json text/css \
  application/x-font-ttf
-
-# Disable etag http header. Doesn't work well with mod_deflate
-# https://issues.apache.org/bugzilla/show_bug.cgi?id=45023
-# Usage of last-modified header and modified-since validator is sufficient.
-Header unset ETag
-FileETag None
 
 # FIXME: WSGISocketPrefix is a server-scope directive.  The mod_wsgi package
 # should really be fixed by adding this its /etc/httpd/conf.d/wsgi.conf:
@@ -95,6 +89,12 @@ WSGIScriptReloading Off
   # legacy clients, the unset here works because it ends up unsetting only one
   # of the 2 header tables set by mod_session, leaving the other intact
   Header unset Set-Cookie
+
+  # Disable etag http header. Doesn't work well with mod_deflate
+  # https://issues.apache.org/bugzilla/show_bug.cgi?id=45023
+  # Usage of last-modified header and modified-since validator is sufficient.
+  Header unset ETag
+  FileETag None
 </Location>
 
 # Target for login with internal connections

--- a/install/ui/Gruntfile.js
+++ b/install/ui/Gruntfile.js
@@ -1,5 +1,8 @@
 module.exports = function(grunt) {
     grunt.initConfig({
+        qunit_junit: {
+            options: {}
+        },
         qunit: {
             all: [
                 'test/all_tests.html'
@@ -7,5 +10,7 @@ module.exports = function(grunt) {
         }
     });
 
+    grunt.loadNpmTasks('grunt-qunit-junit');
     grunt.loadNpmTasks('grunt-contrib-qunit');
+    grunt.registerTask('test', ['qunit_junit', 'qunit']);
 };

--- a/install/ui/src/freeipa/package.json
+++ b/install/ui/src/freeipa/package.json
@@ -42,7 +42,8 @@
   },
   "devDependencies": {
     "grunt": "^1.0.1",
-    "grunt-contrib-qunit": "^2.0.0"
+    "grunt-contrib-qunit": "^2.0.0",
+    "grunt-qunit-junit": "^0.3.1"
   },
   "dependencies": {
     "dojo": "~1.8.1"

--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -928,7 +928,6 @@ class LDAPUpdate(object):
         returns True if anything was changed, otherwise False
         """
         self.modified = False
-        all_updates = []
         try:
             self.create_connection()
 
@@ -937,6 +936,7 @@ class LDAPUpdate(object):
                 upgrade_files = sorted(files)
 
             for f in upgrade_files:
+                start = time.time()
                 try:
                     logger.debug("Parsing update file '%s'", f)
                     data = self.read_file(f)
@@ -944,9 +944,14 @@ class LDAPUpdate(object):
                     logger.error("error reading update file '%s'", f)
                     raise RuntimeError(e)
 
+                all_updates = []
                 self.parse_update_file(f, data, all_updates)
                 self._run_updates(all_updates)
-                all_updates = []
+                dur = time.time() - start
+                logger.debug(
+                    "LDAP update duration: %s %.03f sec", f, dur,
+                    extra={'timing': ('ldapupdate', f, None, dur)}
+                )
         finally:
             self.close_connection()
 

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -10,6 +10,7 @@ import os
 import pickle
 import shutil
 import sys
+import time
 import tempfile
 import textwrap
 
@@ -925,7 +926,11 @@ def install(installer):
             args.append("--no-sshd")
         if options.mkhomedir:
             args.append("--mkhomedir")
+        start = time.time()
         run(args, redirect_output=True)
+        dur = time.time() - start
+        logger.debug("Client install duration: %0.3f", dur,
+                     extra={'timing': ('clientinstall', None, None, dur)})
         print()
     except Exception:
         raise ScriptError("Configuration of client side components failed!")

--- a/ipaserver/plugins/idrange.py
+++ b/ipaserver/plugins/idrange.py
@@ -424,10 +424,10 @@ class idrange_add(LDAPCreate):
             if sid is not None:
                 entry_attrs['ipanttrusteddomainsid'] = sid
             else:
-                raise errors.ValidationError(name='ID Range setup',
-                    error=_('SID for the specified trusted domain name could '
-                            'not be found. Please specify the SID directly '
-                            'using dom-sid option.'))
+                raise errors.ValidationError(
+                    name='ID Range setup',
+                    error=_('Specified trusted domain name could not be '
+                            'found.'))
 
         # ipaNTTrustedDomainSID attribute set, this is AD Trusted domain range
         if is_set('ipanttrusteddomainsid'):

--- a/ipatests/conftest.py
+++ b/ipatests/conftest.py
@@ -104,9 +104,14 @@ def pytest_addoption(parser):
 
 
 def pytest_cmdline_main(config):
-    api.bootstrap(
+    kwargs = dict(
         context=u'cli', in_server=False, in_tree=True, fallback=False
     )
+    if not os.path.isfile(os.path.expanduser('~/.ipa/default.conf')):
+        # dummy domain/host for machines without ~/.ipa/default.conf
+        kwargs.update(domain=u'ipa.test', server=u'master.ipa.test')
+
+    api.bootstrap(**kwargs)
     for klass in cli_plugins:
         api.add_plugin(klass)
 

--- a/ipatests/test_xmlrpc/test_host_plugin.py
+++ b/ipatests/test_xmlrpc/test_host_plugin.py
@@ -649,10 +649,11 @@ class TestHostNoNameserversForRevZone(XMLRPC_test):
             result = command(ip_address=ipv4_in_missingrevzone_ip)
             msg = result['messages'][0]
             assert msg['code'] == messages.FailedToAddHostDNSRecords.errno
-            expected_msg = ("The host was added but the DNS update failed "
-                            "with: All nameservers failed to answer the query "
-                            "for DNS reverse zone {}").format(missingrevzone)
-            assert msg['message'] == expected_msg
+            expected = "The host was added but the DNS update failed"
+            # Either one of:
+            # All nameservers failed to answer the query for DNS reverse zone
+            # DNS reverse zone ... is not managed by this server
+            assert expected in msg['message']
             # Make sure the host is added
             host4.run_command('host_show', host4.fqdn)
         finally:


### PR DESCRIPTION
During ipa-replica-install, http installation first creates a service
principal for http/hostname (locally on the soon-to-be-replica), then
waits for this entry to be replicated on the master picked for the
install.
In a later step, the installer requests a certificate for HTTPd. The local
certmonger first tries the master defined in xmlrpc_uri (which is
pointing to the soon-to-be-replica), but fails because the service is not
up yet. Then certmonger tries to find a master by using the DNS and looking
for a ldap service. This step can pick a different master, where the
principal entry has not always be replicated yet.
As the certificate request adds the principal if it does not exist, we can
end by re-creating the principal and have a replication conflict.

The replication conflict later causes kerberos issues, preventing
from installing a new replica.

The proposed fix forces xmlrpc_uri to point to the same master as the one
picked for the installation, in order to make sure that the master already
contains the principal entry.

https://pagure.io/freeipa/issue/7041