### PR TITLE
ipatests: restore selinux context for fips mode

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -56,19 +56,20 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f33
-          version: 0.0.9
+          name: freeipa/ci-master-f34
+          version: 0.0.4
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_fips:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        selinux_enforcing: True
+        test_suite: test_integration/test_fips.py
         template: *ci-master-latest
-        timeout: 3600
+        timeout: 7200
         topology: *master_1repl_1client

--- a/ipatests/pytest_ipa/integration/fips.py
+++ b/ipatests/pytest_ipa/integration/fips.py
@@ -38,6 +38,9 @@ def enable_userspace_fips(host):
     host.run_command(["mkdir", "-p", FIPS_OVERLAY_DIR])
     host.put_file_contents(FIPS_OVERLAY, "1\n")
     host.run_command(
+        ["chcon", "-t", "sysctl_crypto_t", FIPS_OVERLAY]
+    )
+    host.run_command(
         ["mount", "--bind", FIPS_OVERLAY, paths.PROC_FIPS_ENABLED]
     )
     # set crypto policy to FIPS mode


### PR DESCRIPTION
In order to test FIPS mode, the test is faking a user-space
FIPS environment by creating a file /var/tmp/userspace-fips
+ bind-mounting this file as /proc/sys/crypto/fips_enabled

The security context needs to be restored otherwise
/proc/sys/crypto/fips_enabled inherits the security context
unconfined_u:object_r:user_tmp_t:s0 and cannot be read,
resulting in the test seeing fips_mode=false.

Fixes: https://pagure.io/freeipa/issue/8868