### PR TITLE
Passkey support

### DIFF
--- a/ACI.txt
+++ b/ACI.txt
@@ -222,6 +222,10 @@ dn: cn=ng,cn=alt,dc=ipa,dc=example
 aci: (targetfilter = "(objectclass=ipanisnetgroup)")(version 3.0;acl "permission:System: Remove Netgroups";allow (delete) groupdn = "ldap:///cn=System: Remove Netgroups,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=otp,cn=etc,dc=ipa,dc=example
 aci: (targetattr = "cn || ipatokenhotpauthwindow || ipatokenhotpsyncwindow || ipatokentotpauthwindow || ipatokentotpsyncwindow")(targetfilter = "(objectclass=ipatokenotpconfig)")(version 3.0;acl "permission:System: Read OTP Configuration";allow (compare,read,search) userdn = "ldap:///all";)
+dn: cn=passkeyconfig,cn=etc,dc=ipa,dc=example
+aci: (targetattr = "iparequireuserverification")(targetfilter = "(objectclass=ipapasskeyconfigobject)")(version 3.0;acl "permission:System: Modify Passkey Configuration";allow (write) groupdn = "ldap:///cn=System: Modify Passkey Configuration,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+dn: cn=passkeyconfig,cn=etc,dc=ipa,dc=example
+aci: (targetattr = "cn || iparequireuserverification")(targetfilter = "(objectclass=ipapasskeyconfigobject)")(version 3.0;acl "permission:System: Read Passkey Configuration";allow (compare,read,search) userdn = "ldap:///all";)
 dn: cn=permissions,cn=pbac,dc=ipa,dc=example
 aci: (targetattr = "member")(targetfilter = "(objectclass=ipapermission)")(version 3.0;acl "permission:System: Modify Privilege Membership";allow (write) groupdn = "ldap:///cn=System: Modify Privilege Membership,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: dc=ipa,dc=example

--- a/ACI.txt
+++ b/ACI.txt
@@ -381,6 +381,8 @@ aci: (targetattr = "krbpasswordexpiration || krbprincipalkey || passwordhistory 
 dn: cn=users,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "krbpasswordexpiration || krbprincipalkey || passwordhistory || sambalmpassword || sambantpassword || userpassword")(targetfilter = "(&(!(memberOf=cn=admins,cn=groups,cn=accounts,dc=ipa,dc=example))(objectclass=posixaccount))")(version 3.0;acl "permission:System: Change User password";allow (write) groupdn = "ldap:///cn=System: Change User password,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example
+aci: (targetattr = "ipapasskey || objectclass")(targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Manage Passkey Mappings";allow (write) groupdn = "ldap:///cn=System: Manage Passkey Mappings,cn=permissions,cn=pbac,dc=ipa,dc=example";)
+dn: cn=users,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "ipacertmapdata || objectclass")(targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Manage User Certificate Mappings";allow (write) groupdn = "ldap:///cn=System: Manage User Certificate Mappings,cn=permissions,cn=pbac,dc=ipa,dc=example";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "usercertificate")(targetfilter = "(&(!(memberOf=cn=admins,cn=groups,cn=accounts,dc=ipa,dc=example))(objectclass=posixaccount))")(version 3.0;acl "permission:System: Manage User Certificates";allow (write) groupdn = "ldap:///cn=System: Manage User Certificates,cn=permissions,cn=pbac,dc=ipa,dc=example";)
@@ -397,7 +399,7 @@ aci: (targetattr = "audio || businesscategory || carlicense || departmentnumber 
 dn: dc=ipa,dc=example
 aci: (targetattr = "cn || createtimestamp || entryusn || gecos || gidnumber || homedirectory || loginshell || modifytimestamp || objectclass || uid || uidnumber")(target = "ldap:///cn=users,cn=compat,dc=ipa,dc=example")(version 3.0;acl "permission:System: Read User Compat Tree";allow (compare,read,search) userdn = "ldap:///anyone";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example
-aci: (targetattr = "ipasshpubkey || ipauniqueid || ipauserauthtype || userclass")(targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Read User IPA Attributes";allow (compare,read,search) userdn = "ldap:///all";)
+aci: (targetattr = "ipapasskey || ipasshpubkey || ipauniqueid || ipauserauthtype || userclass")(targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Read User IPA Attributes";allow (compare,read,search) userdn = "ldap:///all";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example
 aci: (targetattr = "krbcanonicalname || krblastpwdchange || krbpasswordexpiration || krbprincipalaliases || krbprincipalexpiration || krbprincipalname || krbprincipaltype || nsaccountlock")(targetfilter = "(objectclass=posixaccount)")(version 3.0;acl "permission:System: Read User Kerberos Attributes";allow (compare,read,search) userdn = "ldap:///all";)
 dn: cn=users,cn=accounts,dc=ipa,dc=example

--- a/API.txt
+++ b/API.txt
@@ -5182,6 +5182,17 @@ option: Str('version?')
 output: Output('completed', type=[<type 'int'>])
 output: Output('failed', type=[<type 'dict'>])
 output: Entry('result')
+command: stageuser_add_passkey/1
+args: 2,4,3
+arg: Str('uid', cli_name='login')
+arg: Str('ipapasskey+', alwaysask=True, cli_name='passkey')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Flag('no_members', autofill=True, default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Str('version?')
+output: Entry('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: PrimaryKey('value')
 command: stageuser_add_principal/1
 args: 2,4,3
 arg: Str('uid', cli_name='login')
@@ -5365,6 +5376,17 @@ option: Str('version?')
 output: Output('completed', type=[<type 'int'>])
 output: Output('failed', type=[<type 'dict'>])
 output: Entry('result')
+command: stageuser_remove_passkey/1
+args: 2,4,3
+arg: Str('uid', cli_name='login')
+arg: Str('ipapasskey+', alwaysask=True, cli_name='passkey')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Flag('no_members', autofill=True, default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Str('version?')
+output: Entry('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: PrimaryKey('value')
 command: stageuser_remove_principal/1
 args: 2,4,3
 arg: Str('uid', cli_name='login')
@@ -6369,6 +6391,17 @@ option: Str('version?')
 output: Output('completed', type=[<type 'int'>])
 output: Output('failed', type=[<type 'dict'>])
 output: Entry('result')
+command: user_add_passkey/1
+args: 2,4,3
+arg: Str('uid', cli_name='login')
+arg: Str('ipapasskey+', alwaysask=True, cli_name='passkey')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Flag('no_members', autofill=True, default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Str('version?')
+output: Entry('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: PrimaryKey('value')
 command: user_add_principal/1
 args: 2,4,3
 arg: Str('uid', cli_name='login')
@@ -6571,6 +6604,17 @@ option: Str('version?')
 output: Output('completed', type=[<type 'int'>])
 output: Output('failed', type=[<type 'dict'>])
 output: Entry('result')
+command: user_remove_passkey/1
+args: 2,4,3
+arg: Str('uid', cli_name='login')
+arg: Str('ipapasskey+', alwaysask=True, cli_name='passkey')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Flag('no_members', autofill=True, default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Str('version?')
+output: Entry('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: PrimaryKey('value')
 command: user_remove_principal/1
 args: 2,4,3
 arg: Str('uid', cli_name='login')
@@ -7337,6 +7381,7 @@ default: stageuser_add/1
 default: stageuser_add_cert/1
 default: stageuser_add_certmapdata/1
 default: stageuser_add_manager/1
+default: stageuser_add_passkey/1
 default: stageuser_add_principal/1
 default: stageuser_del/1
 default: stageuser_find/1
@@ -7344,6 +7389,7 @@ default: stageuser_mod/1
 default: stageuser_remove_cert/1
 default: stageuser_remove_certmapdata/1
 default: stageuser_remove_manager/1
+default: stageuser_remove_passkey/1
 default: stageuser_remove_principal/1
 default: stageuser_show/1
 default: subid/1
@@ -7432,6 +7478,7 @@ default: user_add/1
 default: user_add_cert/1
 default: user_add_certmapdata/1
 default: user_add_manager/1
+default: user_add_passkey/1
 default: user_add_principal/1
 default: user_del/1
 default: user_disable/1
@@ -7441,6 +7488,7 @@ default: user_mod/1
 default: user_remove_cert/1
 default: user_remove_certmapdata/1
 default: user_remove_manager/1
+default: user_remove_passkey/1
 default: user_remove_principal/1
 default: user_show/1
 default: user_stage/1

--- a/API.txt
+++ b/API.txt
@@ -3769,6 +3769,28 @@ option: Str('version?')
 output: Entry('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: PrimaryKey('value')
+command: passkeyconfig_mod/1
+args: 0,8,3
+option: Str('addattr*', cli_name='addattr')
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Str('delattr*', cli_name='delattr')
+option: StrEnum('iparequireuserverification?', autofill=False, cli_name='require_user_verification', values=[u'on', u'off', u'default'])
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Flag('rights', autofill=True, default=False)
+option: Str('setattr*', cli_name='setattr')
+option: Str('version?')
+output: Entry('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: PrimaryKey('value')
+command: passkeyconfig_show/1
+args: 0,4,3
+option: Flag('all', autofill=True, cli_name='all', default=False)
+option: Flag('raw', autofill=True, cli_name='raw', default=False)
+option: Flag('rights', autofill=True, default=False)
+option: Str('version?')
+output: Entry('result')
+output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
+output: PrimaryKey('value')
 command: passwd/1
 args: 3,2,3
 arg: Principal('principal', autofill=True, cli_name='user')
@@ -7191,6 +7213,9 @@ default: output_show/1
 default: param/1
 default: param_find/1
 default: param_show/1
+default: passkeyconfig/1
+default: passkeyconfig_mod/1
+default: passkeyconfig_show/1
 default: passwd/1
 default: permission/1
 default: permission_add/1

--- a/VERSION.m4
+++ b/VERSION.m4
@@ -86,8 +86,8 @@ define(IPA_DATA_VERSION, 20100614120000)
 #                                                      #
 ########################################################
 define(IPA_API_VERSION_MAJOR, 2)
-# Last change: fix vault interoperability issues.
-define(IPA_API_VERSION_MINOR, 251)
+# Last change: add passkey support
+define(IPA_API_VERSION_MINOR, 252)
 
 ########################################################
 # Following values are auto-generated from values above

--- a/doc/api/commands.rst
+++ b/doc/api/commands.rst
@@ -374,6 +374,7 @@ IPA API Commands
    stageuser_add_cert.md
    stageuser_add_certmapdata.md
    stageuser_add_manager.md
+   stageuser_add_passkey.md
    stageuser_add_principal.md
    stageuser_del.md
    stageuser_find.md
@@ -381,6 +382,7 @@ IPA API Commands
    stageuser_remove_cert.md
    stageuser_remove_certmapdata.md
    stageuser_remove_manager.md
+   stageuser_remove_passkey.md
    stageuser_remove_principal.md
    stageuser_show.md
    subid_add.md
@@ -458,6 +460,7 @@ IPA API Commands
    user_add_cert.md
    user_add_certmapdata.md
    user_add_manager.md
+   user_add_passkey.md
    user_add_principal.md
    user_del.md
    user_disable.md
@@ -467,6 +470,7 @@ IPA API Commands
    user_remove_cert.md
    user_remove_certmapdata.md
    user_remove_manager.md
+   user_remove_passkey.md
    user_remove_principal.md
    user_show.md
    user_stage.md

--- a/doc/api/commands.rst
+++ b/doc/api/commands.rst
@@ -267,6 +267,8 @@ IPA API Commands
    output_show.md
    param_find.md
    param_show.md
+   passkeyconfig_mod.md
+   passkeyconfig_show.md
    passwd.md
    permission_add.md
    permission_add_member.md

--- a/doc/api/passkeyconfig_mod.md
+++ b/doc/api/passkeyconfig_mod.md
@@ -1,0 +1,34 @@
+[//]: # (THE CONTENT BELOW IS GENERATED. DO NOT EDIT.)
+# passkeyconfig_mod
+Modify Passkey configuration.
+
+### Arguments
+No arguments.
+
+### Options
+* rights : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* all : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* raw : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* iparequireuserverification : :ref:`StrEnum<StrEnum>`
+ * Values: ('on', 'off', 'default')
+* setattr : :ref:`Str<Str>`
+* addattr : :ref:`Str<Str>`
+* delattr : :ref:`Str<Str>`
+* version : :ref:`Str<Str>`
+
+### Output
+|Name|Type
+|-|-
+|result|Entry
+|summary|Output
+|value|PrimaryKey
+
+[//]: # (ADD YOUR NOTES BELOW. THESE WILL BE PICKED EVERY TIME THE DOCS ARE REGENERATED. //end)
+### Semantics
+
+### Notes
+
+### Version differences

--- a/doc/api/passkeyconfig_show.md
+++ b/doc/api/passkeyconfig_show.md
@@ -1,0 +1,29 @@
+[//]: # (THE CONTENT BELOW IS GENERATED. DO NOT EDIT.)
+# passkeyconfig_show
+Show the current Passkey configuration.
+
+### Arguments
+No arguments.
+
+### Options
+* rights : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* all : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* raw : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* version : :ref:`Str<Str>`
+
+### Output
+|Name|Type
+|-|-
+|result|Entry
+|summary|Output
+|value|PrimaryKey
+
+[//]: # (ADD YOUR NOTES BELOW. THESE WILL BE PICKED EVERY TIME THE DOCS ARE REGENERATED. //end)
+### Semantics
+
+### Notes
+
+### Version differences

--- a/doc/api/stageuser_add_passkey.md
+++ b/doc/api/stageuser_add_passkey.md
@@ -1,0 +1,32 @@
+[//]: # (THE CONTENT BELOW IS GENERATED. DO NOT EDIT.)
+# stageuser_add_passkey
+Add one or more passkey mappings to the stage user entry.
+
+### Arguments
+|Name|Type|Required
+|-|-|-
+|uid|:ref:`Str<Str>`|True
+|ipapasskey|:ref:`Str<Str>`|True
+
+### Options
+* all : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* raw : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* no_members : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* version : :ref:`Str<Str>`
+
+### Output
+|Name|Type
+|-|-
+|result|Entry
+|summary|Output
+|value|PrimaryKey
+
+[//]: # (ADD YOUR NOTES BELOW. THESE WILL BE PICKED EVERY TIME THE DOCS ARE REGENERATED. //end)
+### Semantics
+
+### Notes
+
+### Version differences

--- a/doc/api/stageuser_remove_passkey.md
+++ b/doc/api/stageuser_remove_passkey.md
@@ -1,0 +1,32 @@
+[//]: # (THE CONTENT BELOW IS GENERATED. DO NOT EDIT.)
+# stageuser_remove_passkey
+Remove one or more passkey mappings from the stage user entry.
+
+### Arguments
+|Name|Type|Required
+|-|-|-
+|uid|:ref:`Str<Str>`|True
+|ipapasskey|:ref:`Str<Str>`|True
+
+### Options
+* all : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* raw : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* no_members : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* version : :ref:`Str<Str>`
+
+### Output
+|Name|Type
+|-|-
+|result|Entry
+|summary|Output
+|value|PrimaryKey
+
+[//]: # (ADD YOUR NOTES BELOW. THESE WILL BE PICKED EVERY TIME THE DOCS ARE REGENERATED. //end)
+### Semantics
+
+### Notes
+
+### Version differences

--- a/doc/api/user_add_passkey.md
+++ b/doc/api/user_add_passkey.md
@@ -1,0 +1,32 @@
+[//]: # (THE CONTENT BELOW IS GENERATED. DO NOT EDIT.)
+# user_add_passkey
+Add one or more passkey mappings to the user entry.
+
+### Arguments
+|Name|Type|Required
+|-|-|-
+|uid|:ref:`Str<Str>`|True
+|ipapasskey|:ref:`Str<Str>`|True
+
+### Options
+* all : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* raw : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* no_members : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* version : :ref:`Str<Str>`
+
+### Output
+|Name|Type
+|-|-
+|result|Entry
+|summary|Output
+|value|PrimaryKey
+
+[//]: # (ADD YOUR NOTES BELOW. THESE WILL BE PICKED EVERY TIME THE DOCS ARE REGENERATED. //end)
+### Semantics
+
+### Notes
+
+### Version differences

--- a/doc/api/user_remove_passkey.md
+++ b/doc/api/user_remove_passkey.md
@@ -1,0 +1,32 @@
+[//]: # (THE CONTENT BELOW IS GENERATED. DO NOT EDIT.)
+# user_remove_passkey
+Remove one or more passkey mappings from the user entry.
+
+### Arguments
+|Name|Type|Required
+|-|-|-
+|uid|:ref:`Str<Str>`|True
+|ipapasskey|:ref:`Str<Str>`|True
+
+### Options
+* all : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* raw : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* no_members : :ref:`Flag<Flag>` **(Required)**
+ * Default: False
+* version : :ref:`Str<Str>`
+
+### Output
+|Name|Type
+|-|-
+|result|Entry
+|summary|Output
+|value|PrimaryKey
+
+[//]: # (ADD YOUR NOTES BELOW. THESE WILL BE PICKED EVERY TIME THE DOCS ARE REGENERATED. //end)
+### Semantics
+
+### Notes
+
+### Version differences

--- a/doc/designs/index.rst
+++ b/doc/designs/index.rst
@@ -28,3 +28,4 @@ FreeIPA design documentation
    external-idp/idp-api.md
    random-serial-numbers.md
    client-install-pkinit.md
+   passkeys.md

--- a/doc/designs/passkeys.md
+++ b/doc/designs/passkeys.md
@@ -1,0 +1,268 @@
+# Passkey authentication
+
+## Overview
+
+Traditional authentication with a password is not considered secure enough
+by many companies or government agencies. Alternate and more secure
+solutions exist, among which the use of passkeys, where the private
+key is stored on the device and the server only needs to know the public
+key.
+
+For the purpose of this feature, passkey is a FIDO2 compatible device supported
+by the libfido2 library. For more details, refer to
+https://fidoalliance.org/fido2/
+
+The goal of this feature is to use a passkey to authenticate a user
+against IPA.
+
+The project will be jointly developed by SSSD and IPA:
+
+- IPA provides the interface to store the user's public credentials
+- IPA provides the interface to configure passkey settings
+- SSSD performs the actual authentication
+
+TBD: link to https://sssd.io/ design for the passkey feature
+
+## Use Cases
+
+- The administrator or the user registers a passkey into IPA, associated
+to a user account. The registration process stores a description of the passkey
+bound to IPA deployment and requires a direct communication with the passkey
+device. Alternatively the description string can be obtained through the SSSD
+registration tool and added without the presence of the passkey device.
+- The user is then able to authenticate to any IPA enrolled host using the
+passkey. The first round of passkey integration is targeting a login to
+services implementing login with the help of PAM library locally on the host.
+This includes direct console or graphical desktop login and authentication
+to PAM-protected shell services like 'su' or 'sudo'. To access remote services
+a Kerberos ticket can be obtained and used against those services later.
+
+## How to Use
+
+### Configuration of the passkey settings by the administrator
+
+The administrator is able to specify common settings that will apply:
+
+- require user verification during authentication (On/Off/Default):
+  - On: require user verification during authentication (PIN for instance).
+  - Off: do not require user verification during authentication.
+  - Default: fallback to the passkey’s default behavior.
+
+### Registration of credentials
+
+The user can register credentials for himself, or the admin (or any user with
+the permission "System: Manage User passkeys") can register
+credentials for another user.
+
+During the registration process, it is possible to specify
+- a COSE type: `es256`, `rs256` or `eddsa`
+- request user verification: true or false
+the authentication will force to execute the user verification check even if
+the passkey settings do not set this flag. If credentials are registered without
+the flag, the global passkey settings apply.
+
+When the passkey credential is registered, a relaying party (RP) is set to be
+the IPA domain (e.g. ipa.test). While using a domain-wide relaying party
+reduces access control capabilities for individual application's use of the
+registered passkey, IPA provides own access control mechanisms to be layered
+on top. We choose to combine existing authorization features of IPA with an
+ease of use for the passkeys.
+
+### Authentication
+
+#### Console or desktop authentication
+
+The user has a passkey in his possession that was already registered to IPA
+and has physical access to a machine enrolled in IPA.
+
+At Gnome login, he types his username and inserts the device.
+
+At console login, he types his username and inserts the device.
+
+SSSD validates the credentials and checks that the passkey allows
+authentication.
+
+#### PAM-protected service access
+
+The following example is using the su command, but would apply to any other
+PAM-protected service.
+
+The user passkeyuser has a passkey in his possession that was already
+registered to IPA and has physical access to a machine enrolled in IPA. He
+is already logged into the machine as a different user and wants to perform
+su to authenticate as passkeyuser.
+
+Inside a terminal, he inserts his device and enters the `su - passkeyuser`
+command.
+
+SSSD validates the credentials and checks that the passkey allows
+authentication.
+
+
+## Design
+
+### Configuration of the passkey settings
+
+A new LDAP entry stores the passkey configuration and needs a new objectclass
+and a new attributetype:
+```
+dn: cn=passkeyconfig,cn=etc,$BASEDN
+objectclass: top
+objectclass: nsContainer
+objectclass: ipapasskeyconfigObject
+cn: passkeyconfig
+ipaRequireUserVerification: default
+```
+
+The object class allows a single attribute, require user verification,
+which is mandatory, single valued, and stores a string (on, off, default).
+The LDAP entry is added when IPA server is installed or when the server is
+upgraded to a version supporting passkeys.
+
+### Storage of the passkey mapping
+
+The passkey mapping is stored directly in the user entry. It needs a
+new auxiliary objectclass and a new attributetype.
+
+Note: a first proposal intended to store the value in the ipasshpubkey
+attribute, but this attribute has a special handling (a new fingerprint is
+calculated for each public key and added into the attribute sshpubkeyfp)
+which makes it unsuitable for storing values that are not keys.
+
+The attribute is multi valued, optional.
+
+```
+dn: uid=idmuser,cn=users,cn=accounts,dc=ipa,dc=test
+uid: idmuser
+...
+objectClass: top
+objectClass: person
+...
+objectClass: ipapasskeyuser
+ipapasskey: passkey:9S87qLk8/RxYJ3skwwYduomAM+/HDtz41N0+w/vRL6aGKJkLMsg+2OhO0E8pK5DuO1KmdK61K8PmH7jiYuOqbg==,9YE1s/f7J47h2A/DXCVFWulqoBXFzCSxcbGEBadkpSUFjwUudhPLnPUTv2qNamakXJgRYCZQ7vpS/t5zXMLnkw==
+```
+
+The passkey mapping has the format `passkey:credentialid,pubkey`. credential
+ID and public key are obtained during the registration phase, for instance
+by calling SSSD helper process `sssctl passkey-exec --register` or the IPA Command
+`ipa user-add-passkey LOGIN --register`.
+
+
+### Access control
+
+#### Permissions
+
+- New permission created for writing the passkey configuration:
+`System: Modify Passkey Configuration`. Granted to the Privilege `Passkey Administrators`
+- New permission created for reading the passkey configuration:
+`System: Read Passkey configuration`. Granted to all authenticated users.
+- New permission for managing passkey mapping:
+`System: Manage Passkey Mappings`. Granted to the Privilege: `Passkey Administrators`
+
+- Extend existing permission" `System: Read User IPA Attributes`:
+allow read access to the ipapasskey attribute (granted to all authenticated
+users). This attribute is not sensitive as it contains only public data.
+
+#### Self-service Permission
+
+- New self-service permission for managing their own passkey mapping:
+`Users can manage their own passkey mappings`
+
+#### Privilege
+
+- New privilege `Passkey Administrators` with the permissions `System: Modify Passkey Configuration` and `System: Manage Passkey Mappings`.
+
+By default only members of the admins group are allowed to modify the passkey
+settings or another user's passkeys.
+
+## Implementation
+
+### LDAP schema
+
+New objectclass and attribute for the passkey configuration object:
+```
+attributeTypes: ( 2.16.840.1.113730.3.8.24.26 NAME 'ipaRequireUserVerification' DESC 'require passkey user verification' SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'IPA v4.10')
+objectclasses: ( 2.16.840.1.113730.3.8.24.8 NAME 'ipaPasskeyConfigObject' DESC 'IPA passkey global config options' AUXILIARY MUST ipaRequireUserVerification X-ORIGIN 'IPA v4.10')
+```
+
+New objectclass and attribute for the passkey mapping:
+```
+attributeTypes: ( 2.16.840.1.113730.3.8.24.27 NAME 'ipapasskey' DESC 'Passkey mapping' EQUALITY caseExactMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'IPA v4.10' )
+objectclasses: ( 2.16.840.1.113730.3.8.24.9 NAME 'ipaPasskeyUser' DESC 'IPA passkey user' AUXILIARY MAY ipapasskey X-ORIGIN 'IPA v4.10')
+```
+
+### Indices
+
+No need to add a new index for ipapasskey as the search performed by SSSD
+will use a filter based on the user uid.
+
+
+## Feature Management
+
+### UI
+
+- A new tab will be added below "Policy", at the same level as `Host-Based Access Control`, `Sudo`, `SELInux User Maps`, `Password Policies` and `Kerberos Ticket Policy`, with the label `Passkey Configuration`.
+
+It will allow to configure the attribute `Require User Verification`, with a radio button: `on`, `off` or `default`.
+
+- In the `User` facet, a new field will be added, below `SSH public keys`, with the label `Passkey mappings`, and will display the values, or allow to add a new value.
+
+Note: since the Web browser may be running on a non-enrolled host without
+the required packages, the WebUI will probably need specific javascript code
+to register a key by inserting it on the machine where the browser is
+running.
+
+Investigations TBD regarding the possible solutions. The key registration
+using the WebUI will not be part of the original implementation.
+
+
+### CLI
+
+| Command |	Options | Description |
+| --- | ----- | --- |
+| **Passkey configuration** | | |
+| passkeyconfig-show | | This command displays the Passkey settings |
+| passkeyconfig-mod | --require-user-verification=['on', 'off', 'default'] | This command modifies the Passkey settings |
+| **User Mapping** | | |
+| user-add-passkey | LOGIN [PASSKEY...] | This command does not require the device to be inserted and can directly add the mapping data, obtained through another mean (for instance through sssctl passkey-exec --register) |
+| user-add-passkey | LOGIN --register [--cose-type=['es256', 'rs256', 'eddsa']] [--require-user-verification=BOOL] | This command requires the insertion of the device, performs the registration with the specified cose type + user verification requirement, and adds the mapping data to the user entry |
+| user-remove-passkey | LOGIN PASSKEY... | |
+| user-show | LOGIN | This command displays the passkey mapping if set, with the label `Passkey mapping` |
+| stageuser-add-passkey | LOGIN [PASSKEY...] | This command does not require the device to be inserted and can directly add the mapping data, obtained through another mean (for instance through sssctl passkey-exec --register) |
+| stageuser-add-passkey | LOGIN --register [--cose-type=['es256', 'rs256', 'eddsa']] [--require-user-verification=BOOL] | This command requires the insertion of the passkey, performs the registration with the specified cose type + user verification requirement, and adds the mapping data to the user entry |
+| stageuser-remove-passkey | LOGIN PASSKEY... | |
+| stageuser-show | LOGIN | This command displays the passkey mapping if set, with the label `Passkey mapping` |
+
+
+### Configuration
+
+The global settings can be read or modified using `ipa passkeyconfig-[show|mod]`.
+
+## Upgrade
+
+During upgrade, the new LDAP schema is automatically added and replicated to the replicas.
+
+The upgrade must create the Passkey configuration entry if it does not already exist, with value='default' for the 'require user verification' setting (meaning it will use the default value from each key).
+
+## Test plan
+
+XMLRPC tests must validate the new CLI.
+
+## Troubleshooting and debugging
+
+SSSD provides 2 new commands that can be used for debugging:
+* `/usr/sbin/sssctl passkey-exec --register`: documented and supported. This command can be run as root only.
+* `/usr/libexec/sssd/passkey_child --register`: internally called by `sssctl passkey-exec --register`. This command does not require root access.
+
+IPA command `ipa user-add-passkey --register` internally calls `passkey_child`.
+
+SSSD's helper `passkey_child` provides debugging options:
+
+`passkey_child --register --username=passkeyuser --domain=ipa.test --debug-level=9 --logger=stderr --debug-libfido2`
+
+SSSD's helper can also be used to test the authentication:
+
+`passkey_child --authenticate --username=passkeyuser --domain=ipa.test --public-key=... --key-handle=... --debug-level=9 --logger=stderr --debug-libfido2`
+
+SSSD logs are available in `/var/log/sssd/`.
+

--- a/install/share/60basev4.ldif
+++ b/install/share/60basev4.ldif
@@ -32,3 +32,8 @@ attributeTypes: (2.16.840.1.113730.3.8.23.24 NAME 'ipaIdpUserInfoEndpoint' DESC 
 attributeTypes: (2.16.840.1.113730.3.8.23.25 NAME 'ipaIdpKeysEndpoint' DESC 'Identity Provider JWKS Endpoint' EQUALITY caseExactMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'IPA v4.9' )
 objectClasses: (2.16.840.1.113730.3.8.24.6 NAME 'ipaIdP' SUP top STRUCTURAL DESC 'Identity Provider Configuration' MUST ( cn ) MAY ( ipaIdpDevAuthEndpoint $ ipaIdpAuthEndpoint $ ipaIdpTokenEndpoint $ ipaIdpUserInfoEndpoint $ ipaIdpKeysEndpoint $ ipaIdpClientId $ description $ ipaIdpClientSecret $ ipaIdpScope $ ipaIdpIssuerURL $ ipaIdpSub ) X-ORIGIN 'IPA v4.9' )
 objectClasses: (2.16.840.1.113730.3.8.24.7 NAME 'ipaIdpUser' SUP top AUXILIARY DESC 'User from an external Identity Provider ' MAY ( ipaIdpConfigLink $ ipaIdpSub ) X-ORIGIN 'IPA v4.9' )
+### Passkey support
+attributeTypes: ( 2.16.840.1.113730.3.8.24.26 NAME 'ipaRequireUserVerification' DESC 'require passkey user verification' SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'IPA v4.10')
+attributeTypes: ( 2.16.840.1.113730.3.8.24.27 NAME 'ipapasskey' DESC 'Passkey mapping' EQUALITY caseExactMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'IPA v4.10' )
+objectclasses: ( 2.16.840.1.113730.3.8.24.8 NAME 'ipaPasskeyConfigObject' DESC 'IPA passkey global config options' AUXILIARY MUST ipaRequireUserVerification X-ORIGIN 'IPA v4.10')
+objectclasses: ( 2.16.840.1.113730.3.8.24.9 NAME 'ipaPasskeyUser' DESC 'IPA passkey user' AUXILIARY MAY ipapasskey X-ORIGIN 'IPA v4.10')

--- a/install/updates/73-passkey.update
+++ b/install/updates/73-passkey.update
@@ -12,3 +12,6 @@ default:objectClass: groupofnames
 default:objectClass: nestedgroup
 default:cn: Passkey Administrators
 default:description: Passkey Administrators
+
+dn: $SUFFIX
+add:aci: (targetattr = "ipapasskey")(targattrfilters="add=objectclass:(objectclass=ipapasskeyuser)")(version 3.0;acl "selfservice:Users can manage their own passkey mappings";allow (write) userdn = "ldap:///self";)

--- a/install/updates/73-passkey.update
+++ b/install/updates/73-passkey.update
@@ -1,0 +1,14 @@
+# Configuration for Passkey Authentication
+dn: cn=passkeyconfig,cn=etc,$SUFFIX
+default:objectclass: top
+default:objectclass: nscontainer
+default:objectclass: ipaPasskeyConfigObject
+default:ipaRequireUserVerification: default
+
+# Passkey Administrators
+dn: cn=Passkey Administrators,cn=privileges,cn=pbac,$SUFFIX
+default:objectClass: top
+default:objectClass: groupofnames
+default:objectClass: nestedgroup
+default:cn: Passkey Administrators
+default:description: Passkey Administrators

--- a/install/updates/Makefile.am
+++ b/install/updates/Makefile.am
@@ -66,6 +66,7 @@ app_DATA =				\
 	73-subid.update		\
 	73-winsync.update		\
 	73-certmap.update		\
+	73-passkey.update		\
 	75-user-trust-attributes.update	\
 	80-schema_compat.update 	\
 	81-externalmembers.update	\

--- a/ipaclient/plugins/baseuser.py
+++ b/ipaclient/plugins/baseuser.py
@@ -1,0 +1,93 @@
+#
+# Copyright (C) 2022  FreeIPA Contributors see COPYING for license
+#
+
+import os
+import locale
+import logging
+import subprocess
+from ipaclient.frontend import MethodOverride
+from ipalib import errors
+from ipalib import Bool, Flag, StrEnum
+from ipalib.text import _
+from ipaplatform.paths import paths
+
+logger = logging.getLogger(__name__)
+
+
+class baseuser_add_passkey(MethodOverride):
+    takes_options = (
+        Flag(
+            'register',
+            cli_name='register',
+            doc=_('Register the passkey'),
+        ),
+        Bool(
+            'require_user_verification?',
+            cli_name='require_user_verification',
+            doc=_('Require user verification during authentication with '
+                  'the passkey')
+        ),
+        StrEnum(
+            'cosetype?',
+            cli_name='cose_type',
+            doc=_('COSE type to use for registration'),
+            values=('es256', 'rs256', 'eddsa'),
+        ),
+    )
+
+    def get_args(self):
+        # ipapasskey is not mandatory as it can be built
+        # from the registration step
+        for arg in super(baseuser_add_passkey, self).get_args():
+            if arg.name == 'ipapasskey':
+                yield arg.clone(required=False, alwaysask=False)
+            else:
+                yield arg.clone()
+
+    def forward(self, *args, **options):
+        if self.api.env.context == 'cli':
+            # 2 formats are possible for ipa user-add-passkey:
+            # --register [--require-user-verification] [--cose-type ...]
+            # or
+            # passkey:<key id>,<pub key>
+            for option in super(baseuser_add_passkey, self).get_options():
+                if args and option in options:
+                    raise errors.MutuallyExclusiveError(
+                        reason=_("cannot specify both %s and "
+                                 "passkey mapping").format(option))
+            # if the first format is used, need to register the key first
+            # and obtained the data
+            if 'register' in options:
+                # Ensure the executable exists
+                if not os.path.exists(paths.PASSKEY_CHILD):
+                    raise errors.ValidationError(name="register", error=_(
+                        "Missing executable %s, use the command with "
+                        "LOGIN PASSKEY instead of LOGIN --register")
+                        % paths.PASSKEY_CHILD)
+
+                options.pop('register')
+                cosetype = options.pop('cosetype', None)
+                require_verif = options.pop('require_user_verification', None)
+                cmd = [paths.PASSKEY_CHILD, "--register",
+                       "--domain", self.api.env.domain,
+                       "--username", args[0]]
+                if cosetype:
+                    cmd.append("--type")
+                    cmd.append(cosetype)
+                if require_verif is not None:
+                    cmd.append("--user-verification")
+                    cmd.append(str(require_verif).lower())
+
+                logger.debug("Executing command: %s", cmd)
+                subp = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+                stdout, _stderr = subp.communicate(None)
+
+                if subp.returncode != 0:
+                    raise errors.NotFound(reason="Failed to generate passkey")
+
+                passkey = stdout.decode(locale.getpreferredencoding(),
+                                        errors='replace').strip()
+                args = (args[0], [passkey])
+
+        return super(baseuser_add_passkey, self).forward(*args, **options)

--- a/ipaclient/plugins/stageuser.py
+++ b/ipaclient/plugins/stageuser.py
@@ -1,0 +1,14 @@
+#
+# Copyright (C) 2022  FreeIPA Contributors see COPYING for license
+#
+from ipaclient.plugins.baseuser import baseuser_add_passkey
+from ipalib.plugable import Registry
+from ipalib import _
+
+
+register = Registry()
+
+
+@register(override=True, no_fail=True)
+class stageuser_add_passkey(baseuser_add_passkey):
+    __doc__ = _("Add one or more passkey mappings to the user entry.")

--- a/ipaclient/plugins/user.py
+++ b/ipaclient/plugins/user.py
@@ -19,6 +19,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from ipaclient.frontend import MethodOverride
+from ipaclient.plugins.baseuser import baseuser_add_passkey
 from ipalib import errors
 from ipalib import Flag
 from ipalib import util
@@ -79,3 +80,8 @@ class user_show(MethodOverride):
                 raise errors.NoCertificateError(entry=keys[-1])
         else:
             return super(user_show, self).forward(*keys, **options)
+
+
+@register(override=True, no_fail=True)
+class user_add_passkey(baseuser_add_passkey):
+    __doc__ = _("Add one or more passkey mappings to the user entry.")

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -156,6 +156,7 @@ DEFAULT_CONFIG = (
         DN(('cn', 'ca_renewal'), ('cn', 'ipa'), ('cn', 'etc'))),
     ('container_subids', DN(('cn', 'subids'), ('cn', 'accounts'))),
     ('container_idp', DN(('cn', 'idp'))),
+    ('container_passkey', DN(('cn', 'passkeyconfig'), ('cn', 'etc'))),
 
     # Ports, hosts, and URIs:
     # Following values do not have any reasonable default.

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -463,6 +463,7 @@ class BasePathNamespace:
         "/var/lib/gssproxy/ipa_ccache_sweeper.sock"
     )
     PAM_CONFIG = None
+    PASSKEY_CHILD = '/usr/libexec/sssd/passkey_child'
 
     def check_paths(self):
         """Check paths for missing files

--- a/ipaserver/plugins/passkeyconfig.py
+++ b/ipaserver/plugins/passkeyconfig.py
@@ -1,0 +1,95 @@
+#
+# Copyright (C) 2022  FreeIPA Contributors see COPYING for license
+#
+
+import logging
+
+from ipalib import api
+from ipalib.parameters import StrEnum
+from ipalib.plugable import Registry
+from .baseldap import (
+    LDAPObject,
+    LDAPRetrieve,
+    LDAPUpdate)
+from ipalib import _
+
+
+logger = logging.getLogger(__name__)
+
+__doc__ = _("""
+Passkey configuration
+""") + _("""
+Manage Passkey configuration.
+""") + _("""
+IPA supports the use of passkeys for authentication. A passkey
+device has to be registered to SSSD and the resulting authentication mapping
+stored in the user entry.
+The passkey authentication supports the following configuration option:
+require user verification. When set, the method for user verification depends
+on the type of device (PIN, fingerprint, external pad...)
+""") + _("""
+EXAMPLES:
+""") + _("""
+ Display the Passkey configuration:
+   ipa passkeyconfig-show
+""") + _("""
+ Modify the Passkey configuration to always require user verification:
+   ipa passkeyconfig-mod --require-user-verification=on
+""")
+
+register = Registry()
+
+
+@register()
+class passkeyconfig(LDAPObject):
+    """
+    Passkey configuration object
+    """
+    object_name = _('Passkey configuration options')
+    default_attributes = ['iparequireuserverification']
+
+    container_dn = api.env.container_passkey
+    label = _('Passkey Configuration')
+    label_singular = _('Passkey Configuration')
+
+    takes_params = (
+        StrEnum(
+            'iparequireuserverification',
+            cli_name="require_user_verification",
+            label=_("Require user verification"),
+            doc=_('Require user verification during authentication'),
+            values=('on', 'off', 'default'),
+        ),
+    )
+
+    permission_filter_objectclasses = ['ipapasskeyconfigobject']
+    managed_permissions = {
+        'System: Read Passkey Configuration': {
+            'replaces_global_anonymous_aci': True,
+            'ipapermbindruletype': 'all',
+            'ipapermright': {'read', 'search', 'compare'},
+            'ipapermdefaultattr': {
+                'iparequireuserverification',
+                'cn',
+            },
+        },
+        'System: Modify Passkey Configuration': {
+            'replaces_global_anonymous_aci': True,
+            'ipapermright': {'write'},
+            'ipapermdefaultattr': {
+                'iparequireuserverification',
+            },
+            'default_privileges': {
+                'Passkey Administrators'},
+        },
+    }
+
+
+@register()
+class passkeyconfig_mod(LDAPUpdate):
+    __doc__ = _("Modify Passkey configuration.")
+
+
+@register()
+class passkeyconfig_show(LDAPRetrieve):
+    __doc__ = _("Show the current Passkey configuration.")

--- a/ipaserver/plugins/stageuser.py
+++ b/ipaserver/plugins/stageuser.py
@@ -49,7 +49,9 @@ from .baseuser import (
     baseuser_add_manager,
     baseuser_remove_manager,
     baseuser_add_certmapdata,
-    baseuser_remove_certmapdata)
+    baseuser_remove_certmapdata,
+    baseuser_add_passkey,
+    baseuser_remove_passkey)
 from ipalib.request import context
 from ipalib.util import set_krbcanonicalname
 from ipalib import _, ngettext
@@ -812,4 +814,16 @@ class stageuser_add_certmapdata(baseuser_add_certmapdata):
 @register()
 class stageuser_remove_certmapdata(baseuser_remove_certmapdata):
     __doc__ = _("Remove one or more certificate mappings from the stage user"
+                " entry.")
+
+
+@register()
+class stageuser_add_passkey(baseuser_add_passkey):
+    __doc__ = _("Add one or more passkey mappings to the stage user"
+                " entry.")
+
+
+@register()
+class stageuser_remove_passkey(baseuser_remove_passkey):
+    __doc__ = _("Remove one or more passkey mappings from the stage user"
                 " entry.")

--- a/ipatests/test_xmlrpc/objectclasses.py
+++ b/ipatests/test_xmlrpc/objectclasses.py
@@ -244,3 +244,9 @@ idp = [
     'top',
     'ipaidp',
 ]
+
+passkeyconfig = [
+    'top',
+    'nscontainer',
+    'ipapasskeyconfigobject',
+]

--- a/ipatests/test_xmlrpc/test_passkey_plugin.py
+++ b/ipatests/test_xmlrpc/test_passkey_plugin.py
@@ -1,0 +1,144 @@
+#
+# Copyright (C) 2022  FreeIPA Contributors see COPYING for license
+#
+
+import pytest
+
+from ipalib import errors
+from ipatests.test_xmlrpc.xmlrpc_test import XMLRPC_test, raises_exact
+from ipatests.test_xmlrpc.tracker.passkey_plugin import PasskeyconfigTracker
+from ipatests.test_xmlrpc.tracker.user_plugin import UserTracker
+from ipatests.test_xmlrpc.tracker.stageuser_plugin import StageUserTracker
+
+
+@pytest.fixture(scope='class')
+def passkey_config(request, xmlrpc_setup):
+    tracker = PasskeyconfigTracker()
+    return tracker.make_fixture(request)
+
+
+class TestPasskeyconfig(XMLRPC_test):
+    @pytest.mark.parametrize("userverification", ['on', 'off', 'default'])
+    def test_config_mod(self, passkey_config, userverification):
+        """
+        Test the passkeyconfig-mod CLI with possible values for
+        --require-user-verification parameter.
+        """
+        passkey_config.update(
+            {'iparequireuserverification': userverification},
+            {'iparequireuserverification': [userverification]}
+        )
+
+    def test_config_mod_invalid_requireverif(self, passkey_config):
+        """
+        Test the passkeyconfig-mod CLI with invalid values for
+        --require-user-verification parameter.
+        """
+        cmd = passkey_config.make_update_command(
+            updates={'iparequireuserverification': 'Invalid'}
+        )
+
+        with pytest.raises(errors.ValidationError):
+            cmd()
+
+    def test_config_show(self, passkey_config):
+        """
+        Test the passkeyconfig-show command.
+        """
+        passkey_config.retrieve()
+
+
+PASSKEY_USER = 'passkeyuser'
+PASSKEY_KEY = ("passkey:"
+               "E8Zay6UJm6PG/GcQnej2WMyUrWqijejBCqPWFX6THPrx"
+               "ab01Z59bUgutipn5MIk8/zMU6RBlp7jSbkNJsZtomw==,"
+               "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgryfr3YR"
+               "M9OVdWHEDrbvcSyT5D0b/8Ks+fMp8MM0BXV/FOo436ZP"
+               "jUqSU+2LOXVGdKkJU1XBiwl+n/X+vGD1vw==")
+
+
+@pytest.fixture
+def passkeyuser(request):
+    user = UserTracker(PASSKEY_USER, 'passkey', 'user')
+    return user.make_fixture(request)
+
+
+class TestAddRemovePasskey(XMLRPC_test):
+    def test_add_passkey(self, passkeyuser):
+        passkeyuser.ensure_exists()
+        passkeyuser.add_passkey(ipapasskey=PASSKEY_KEY)
+        passkeyuser.ensure_missing()
+
+    def test_remove_passkey(self, passkeyuser):
+        passkeyuser.ensure_exists()
+        passkeyuser.add_passkey(ipapasskey=PASSKEY_KEY)
+        passkeyuser.remove_passkey(ipapasskey=PASSKEY_KEY)
+
+    @pytest.mark.parametrize("key", ['wrongval', 'passkey:123', 'passkey,123'])
+    def test_add_passkey_invalid(self, passkeyuser, key):
+        passkeyuser.ensure_exists()
+        cmd = passkeyuser.make_command('user_add_passkey',
+                                       passkeyuser.name)
+        with raises_exact(errors.ValidationError(
+                name='passkey',
+                error='"{}" is not a valid passkey mapping'.format(key))):
+            cmd(key)
+
+    def test_add_passkey_invalidid(self, passkeyuser):
+        passkeyuser.ensure_exists()
+        key = ("passkey:123,"
+               "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgryfr3YRM9OVdWHEDrbvc"
+               "SyT5D0b/8Ks+fMp8MM0BXV/FOo436ZPjUqSU+2LOXVGdKkJU1XBiwl+n/X"
+               "+vGD1vw==")
+        msg = '"{}" is not a valid passkey mapping, invalid id'
+        cmd = passkeyuser.make_command('user_add_passkey',
+                                       passkeyuser.name)
+        with raises_exact(errors.ValidationError(
+                name='passkey',
+                error=msg.format(key))):
+            cmd(key)
+
+    def test_add_passkey_invalidpem(self, passkeyuser):
+        passkeyuser.ensure_exists()
+        key = ("passkey:"
+               "E8Zay6UJm6PG/GcQnej2WMyUrWqijejBCqPWFX6THPrxab01Z59bUguti"
+               "pn5MIk8/zMU6RBlp7jSbkNJsZtomw==,"
+               "wrongpem")
+        msg = '"{}" is not a valid passkey mapping, invalid key'
+        cmd = passkeyuser.make_command('user_add_passkey',
+                                       passkeyuser.name)
+        with raises_exact(errors.ValidationError(
+                name='passkey',
+                error=msg.format(key))):
+            cmd(key)
+
+
+STAGEPASSKEY_USER = 'stagepasskeyuser'
+
+
+@pytest.fixture
+def stagepasskeyuser(request):
+    user = StageUserTracker(STAGEPASSKEY_USER, 'stagepasskey', 'user')
+    return user.make_fixture(request)
+
+
+class TestStageAddRemovePassKey(XMLRPC_test):
+    def test_add_passkey(self, stagepasskeyuser):
+        stagepasskeyuser.ensure_exists()
+        stagepasskeyuser.add_passkey(ipapasskey=PASSKEY_KEY)
+        stagepasskeyuser.ensure_missing()
+
+    def test_remove_passkey(self, stagepasskeyuser):
+        stagepasskeyuser.ensure_exists()
+        stagepasskeyuser.add_passkey(ipapasskey=PASSKEY_KEY)
+        stagepasskeyuser.remove_passkey(ipapasskey=PASSKEY_KEY)
+
+    @pytest.mark.parametrize("key", ['wrongval', 'passkey:123', 'passkey,123'])
+    def test_add_passkey_invalid(self, stagepasskeyuser, key):
+        stagepasskeyuser.ensure_exists()
+        cmd = stagepasskeyuser.make_command('user_add_passkey',
+                                            stagepasskeyuser.name)
+        with raises_exact(errors.ValidationError(
+                name='passkey',
+                error='"{}" is not a valid passkey mapping'.format(key))):
+            cmd(key)

--- a/ipatests/test_xmlrpc/tracker/passkey_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/passkey_plugin.py
@@ -1,0 +1,126 @@
+#
+# Copyright (C) 2022  FreeIPA Contributors see COPYING for license
+#
+
+from ipapython.dn import DN
+from ipatests.test_xmlrpc import objectclasses
+from ipatests.test_xmlrpc.tracker.base import ConfigurationTracker
+from ipatests.test_xmlrpc.xmlrpc_test import fuzzy_string
+from ipatests.util import assert_deepequal
+
+
+class PasskeyconfigTracker(ConfigurationTracker):
+    retrieve_keys = {
+        'dn',
+        'iparequireuserverification',
+    }
+
+    retrieve_all_keys = retrieve_keys | {
+        'cn',
+        'objectclass',
+        'aci',
+    }
+
+    update_keys = retrieve_keys - {'dn'}
+    singlevalue_keys = {'iparequireuserverification'}
+
+    def __init__(self, default_version=None):
+        super(PasskeyconfigTracker, self).__init__(
+            default_version=default_version)
+
+        self.attrs = {
+            'dn': DN(self.api.env.container_passkey, self.api.env.basedn),
+            'cn': [self.api.env.container_passkey[0].value],
+            'objectclass': objectclasses.passkeyconfig,
+            'aci': [fuzzy_string],
+            'iparequireuserverif': self.api.Command.passkeyconfig_show(
+            )['result']['iparequireuserverification'],
+        }
+
+    def make_update_command(self, updates):
+        return self.make_command('passkeyconfig_mod', **updates)
+
+    def check_update(self, result, extra_keys=()):
+        assert_deepequal(
+            dict(
+                value=None,
+                summary=None,
+                result=self.filter_attrs(self.update_keys | set(extra_keys)),
+            ),
+            result
+        )
+
+    def make_retrieve_command(self, all=False, raw=False):
+        return self.make_command('passkeyconfig_show', all=all, raw=raw)
+
+    def check_retrieve(self, result, all=False, raw=False):
+        if all:
+            expected = self.filter_attrs(self.retrieve_all_keys)
+        else:
+            expected = self.filter_attrs(self.retrieve_keys)
+        assert_deepequal(
+            dict(
+                value=None,
+                summary=None,
+                result=expected,
+            ),
+            result
+        )
+
+
+class PasskeyMixin:
+    def _make_add_passkey(self):
+        raise NotImplementedError("_make_add_passkey method must be "
+                                  "implemented in instance.")
+
+    def _make_remove_passkey(self):
+        raise NotImplementedError("_make_remove_passkey method must be "
+                                  "implemented in instance.")
+
+    def add_passkey(self, **kwargs):
+        cmd = self._make_add_passkey()
+        result = cmd(**kwargs)
+        data = kwargs.get('ipapasskey', [])
+        if not isinstance(data, list):
+            data = [data]
+        self.attrs.setdefault('ipapasskey', []).extend(data)
+
+        expected = dict(
+            summary=('Added passkey mappings to user '
+                     '"{}"'.format(self.name)),
+            value=self.name,
+            result=dict(
+                uid=(self.name,),
+            ),
+        )
+
+        if self.attrs['ipapasskey']:
+            expected['result']['ipapasskey'] = (
+                self.attrs['ipapasskey'])
+
+        assert_deepequal(expected, result)
+
+    def remove_passkey(self, **kwargs):
+        cmd = self._make_remove_passkey()
+
+        result = cmd(**kwargs)
+        data = kwargs.get('ipapasskey', [])
+        if not isinstance(data, list):
+            data = [data]
+
+        for key in data:
+            self.attrs['ipapasskey'].remove(key)
+
+        expected = dict(
+            summary=('Removed passkey mappings from user '
+                     '"{}"'.format(self.name)),
+            value=self.name,
+            result=dict(
+                uid=(self.name,),
+            ),
+        )
+        if self.attrs['ipapasskey']:
+            expected['result']['ipapasskey'] = (
+                self.attrs['ipapasskey'])
+
+        assert_deepequal(expected, result)

--- a/ipatests/test_xmlrpc/tracker/stageuser_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/stageuser_plugin.py
@@ -8,6 +8,7 @@ from ipalib import api, errors
 from ipaplatform.constants import constants as platformconstants
 
 from ipatests.test_xmlrpc.tracker.base import Tracker
+from ipatests.test_xmlrpc.tracker.passkey_plugin import PasskeyMixin
 from ipatests.test_xmlrpc.tracker.kerberos_aliases import KerberosAliasMixin
 from ipatests.test_xmlrpc import objectclasses
 from ipatests.test_xmlrpc.xmlrpc_test import (
@@ -30,7 +31,7 @@ sshpubkeyfp = (u'SHA256:cStA9o5TRSARbeketEOooMUMSWRSsArIAXloBZ4vNsE '
                'public key test (ssh-rsa)')
 
 
-class StageUserTracker(KerberosAliasMixin, Tracker):
+class StageUserTracker(PasskeyMixin, KerberosAliasMixin, Tracker):
     """ Tracker class for staged user LDAP object
 
         Implements helper functions for host plugin.
@@ -285,3 +286,10 @@ class StageUserTracker(KerberosAliasMixin, Tracker):
 
     def _make_remove_alias_cmd(self):
         return self.make_command('stageuser_remove_principal', self.name)
+
+    # Passkey mapping methods
+    def _make_add_passkey(self):
+        return self.make_command('stageuser_add_passkey', self.name)
+
+    def _make_remove_passkey(self):
+        return self.make_command('stageuser_remove_passkey', self.name)

--- a/ipatests/test_xmlrpc/tracker/user_plugin.py
+++ b/ipatests/test_xmlrpc/tracker/user_plugin.py
@@ -16,12 +16,14 @@ from ipatests.test_xmlrpc.xmlrpc_test import (
 from ipatests.test_xmlrpc.tracker.base import Tracker
 from ipatests.test_xmlrpc.tracker.kerberos_aliases import KerberosAliasMixin
 from ipatests.test_xmlrpc.tracker.certmapdata import CertmapdataMixin
+from ipatests.test_xmlrpc.tracker.passkey_plugin import PasskeyMixin
 
 if six.PY3:
     unicode = str
 
 
-class UserTracker(CertmapdataMixin, KerberosAliasMixin, Tracker):
+class UserTracker(PasskeyMixin, CertmapdataMixin, KerberosAliasMixin,
+                  Tracker):
     """ Class for host plugin like tests """
 
     retrieve_keys = {
@@ -312,7 +314,7 @@ class UserTracker(CertmapdataMixin, KerberosAliasMixin, Tracker):
             result=expected,
         ), result)
 
-    def check_find(self, result, all=False, pkey_only=False, raw=False,
+    def check_find(self, result, all=False, raw=False, pkey_only=False,
                    expected_override=None):
         """ Check 'user-find' command result """
         if all:
@@ -553,3 +555,10 @@ class UserTracker(CertmapdataMixin, KerberosAliasMixin, Tracker):
 
     def _make_remove_certmap(self):
         return self.make_command('user_remove_certmapdata', self.name)
+
+    # Passkey mapping methods
+    def _make_add_passkey(self):
+        return self.make_command('user_add_passkey', self.name)
+
+    def _make_remove_passkey(self):
+        return self.make_command('user_remove_passkey', self.name)

--- a/pylint_plugins.py
+++ b/pylint_plugins.py
@@ -419,6 +419,7 @@ AstroidBuilder(MANAGER).string_build(textwrap.dedent(
     api.env.container_dna_posix_ids = DN()
     api.env.container_dns = DN()
     api.env.container_dnsservers = DN()
+    api.env.container_passkey = DN()
     api.env.container_group = DN()
     api.env.container_hbac = DN()
     api.env.container_hbacservice = DN()


### PR DESCRIPTION
Add support for passkey.

This is still WIP:

- the webUI part is missing
- need to investigate how to register a FIDO2 key from webui

What can already be tested:

- new commands to read/modify the FIDO2 config (require user verification)
- new commands to add/remove a FIDO2 key mapping to a user or a stageuser
- new command ipa user-add-passkey idmuser --register with the passkey helper provided by SSSD
