### PR TITLE
ipa-kdb: initial support for passkeys

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb.c
+++ b/daemons/ipa-kdb/ipa_kdb.c
@@ -200,6 +200,7 @@ static const struct {
     { "pkinit", IPADB_USER_AUTH_PKINIT },
     { "hardened", IPADB_USER_AUTH_HARDENED },
     { "idp", IPADB_USER_AUTH_IDP },
+    { "passkey", IPADB_USER_AUTH_PASSKEY },
     { }
 };
 

--- a/daemons/ipa-kdb/ipa_kdb.h
+++ b/daemons/ipa-kdb/ipa_kdb.h
@@ -106,6 +106,7 @@ enum ipadb_user_auth {
   IPADB_USER_AUTH_PKINIT   = 1 << 4,
   IPADB_USER_AUTH_HARDENED = 1 << 5,
   IPADB_USER_AUTH_IDP      = 1 << 6,
+  IPADB_USER_AUTH_PASSKEY  = 1 << 7,
 };
 
 enum ipadb_user_auth_idx {
@@ -114,6 +115,7 @@ enum ipadb_user_auth_idx {
   IPADB_USER_AUTH_IDX_PKINIT,
   IPADB_USER_AUTH_IDX_HARDENED,
   IPADB_USER_AUTH_IDX_IDP,
+  IPADB_USER_AUTH_IDX_PASSKEY,
   IPADB_USER_AUTH_IDX_MAX,
 };
 

--- a/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
+++ b/daemons/ipa-kdb/ipa_kdb_kdcpolicy.c
@@ -143,6 +143,15 @@ ipa_kdcpolicy_check_as(krb5_context context, krb5_kdcpolicy_moddata moddata,
                 goto done;
             }
             pol_limits = &(ied->pol_limits[IPADB_USER_AUTH_IDX_IDP]);
+        } else if (strcmp(auth_indicator, "passkey") == 0) {
+            valid_auth_indicators++;
+            /* Allow hardened even if only password pre-auth is allowed */
+            if (!(ua & IPADB_USER_AUTH_PASSKEY)) {
+                *status = "Passkey pre-authentication not allowed for this user.";
+                kerr = KRB5KDC_ERR_POLICY;
+                goto done;
+            }
+            pol_limits = &(ied->pol_limits[IPADB_USER_AUTH_IDX_PASSKEY]);
         }
     }
 

--- a/ipatests/test_webui/test_subid.py
+++ b/ipatests/test_webui/test_subid.py
@@ -146,5 +146,5 @@ class test_subid(UI_driver):
         with pytest.raises(NoSuchElementException) as excinfo:
             self.delete_record(admin_uid, table_name="ipauniqueid")
         # Ensure that the exception is really related to missing remove button
-        msg = "Unable to locate element: .facet-controls button[name=remove]"
-        assert msg in str(excinfo)
+        msg = r"Unable to locate element: .facet-controls button\[name=remove\]"
+        assert excinfo.match(msg)


### PR DESCRIPTION
- added passkey detection based on the presence of ipaPassKey attribute in the LDAP entry of the principal
- added 'passkey' authentication indicator
- added support for enforcing KDC policy based on the 'passkey' indicator

TODO: add reading global passkey configuration and enforcement of the user verification flag

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>