### PR TITLE
Passkey: add support for discoverable credentials

### DIFF
--- a/doc/designs/passkeys.md
+++ b/doc/designs/passkeys.md
@@ -60,6 +60,8 @@ During the registration process, it is possible to specify
 the authentication will force to execute the user verification check even if
 the passkey settings do not set this flag. If credentials are registered without
 the flag, the global passkey settings apply.
+- credential type: `server-side` or `discoverable`
+Discoverable credentials do not require to first identify the user.
 
 When the passkey credential is registered, a relaying party (RP) is set to be
 the IPA domain (e.g. ipa.test). While using a domain-wide relaying party

--- a/ipaclient/plugins/baseuser.py
+++ b/ipaclient/plugins/baseuser.py
@@ -34,6 +34,12 @@ class baseuser_add_passkey(MethodOverride):
             doc=_('COSE type to use for registration'),
             values=('es256', 'rs256', 'eddsa'),
         ),
+        StrEnum(
+            'credtype?',
+            cli_name="cred_type",
+            doc=_('Credential type'),
+            values=('server-side', 'discoverable'),
+        ),
     )
 
     def get_args(self):
@@ -69,6 +75,7 @@ class baseuser_add_passkey(MethodOverride):
                 options.pop('register')
                 cosetype = options.pop('cosetype', None)
                 require_verif = options.pop('require_user_verification', None)
+                credtype = options.pop('credtype', None)
                 cmd = [paths.PASSKEY_CHILD, "--register",
                        "--domain", self.api.env.domain,
                        "--username", args[0]]
@@ -78,6 +85,9 @@ class baseuser_add_passkey(MethodOverride):
                 if require_verif is not None:
                     cmd.append("--user-verification")
                     cmd.append(str(require_verif).lower())
+                if credtype:
+                    cmd.append("--cred-type")
+                    cmd.append(credtype)
 
                 logger.debug("Executing command: %s", cmd)
                 subp = subprocess.Popen(cmd, stdout=subprocess.PIPE)

--- a/ipaserver/plugins/baseuser.py
+++ b/ipaserver/plugins/baseuser.py
@@ -167,14 +167,15 @@ def validate_passkey(ugettext, key):
 
     The expected format is passkey:<key id>,<pubkey>
     """
-    pattern = re.compile(r'passkey:(?P<id>.*),(?P<pkey>.*)')
+    pattern = re.compile(
+        r'^passkey:(?P<id>[^,]*),(?P<pkey>[^,]*),?(?P<userid>.*)$')
     result = re.match(pattern, key)
     if result is None:
         return '"%s" is not a valid passkey mapping' % key
 
     # Validate the id part
     try:
-        base64.b64decode(result.group('id'))
+        base64.b64decode(result.group('id'), validate=True)
     except Exception:
         return '"%s" is not a valid passkey mapping, invalid id' % key
 
@@ -187,6 +188,13 @@ def validate_passkey(ugettext, key):
                             backend=default_backend())
     except ValueError:
         return '"%s" is not a valid passkey mapping, invalid key' % key
+    # Validate the (optional) userid
+    try:
+        userid = result.group('userid')
+        if userid:
+            base64.b64decode(userid, validate=True)
+    except Exception:
+        return '"%s" is not a valid passkey mapping, invalid userid' % key
     return None
 
 


### PR DESCRIPTION
Apart from server-side credentials passkey should also register discoverable credentials.
ipa user-add-passkey --register now supports an additional option, --cred-type server-side|discoverable
that is propagated to passkey_child command.

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>