### PR TITLE
Passkey: add "passkey configuration" to webui

### DIFF
--- a/install/ui/src/freeipa/app.js
+++ b/install/ui/src/freeipa/app.js
@@ -44,6 +44,7 @@ define([
     './idviews',
     './netgroup',
     './otptoken',
+    './passkeyconfig',
     './policy',
     './radiusproxy',
     './realmdomains',

--- a/install/ui/src/freeipa/navigation/menu_spec.js
+++ b/install/ui/src/freeipa/navigation/menu_spec.js
@@ -149,7 +149,8 @@ var nav = {};
                 },
                 { entity: 'selinuxusermap' },
                 { entity: 'pwpolicy' },
-                { entity: 'krbtpolicy' }
+                { entity: 'krbtpolicy' },
+                { entity: 'passkeyconfig' }
             ]
         },
         {

--- a/install/ui/src/freeipa/passkeyconfig.js
+++ b/install/ui/src/freeipa/passkeyconfig.js
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (C) 2022  FreeIPA Contributors see COPYING for license
+ */
+
+define([
+        './ipa',
+        './jquery',
+        './phases',
+        './reg',
+        './details',
+        './search',
+        './association',
+        './entity'],
+            function(IPA, $, phases, reg) {
+
+var exp = IPA.passkeyconfig = {};
+
+var make_spec = function() {
+return {
+    name: 'passkeyconfig',
+    defines_key: false,
+    facets: [
+        {
+            $type: 'details',
+            title: '@mo:config.label',
+            sections: [
+                {
+                    name: 'options',
+                    label: '@i18n:objects.passkeyconfig.options',
+                    fields: [
+                        {
+                            $type: 'radio',
+                            name: 'iparequireuserverification',
+                            default_value: 'default',
+                            options: [
+                                {
+                                    value: 'on',
+                                    label: '@i18n:objects.passkeyconfig.on'
+                                },
+                                {
+                                    value: 'off',
+                                    label: '@i18n:objects.passkeyconfig.off'
+                                },
+                                {
+                                    value: 'default',
+                                    label: '@i18n:objects.passkeyconfig.default'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            needs_update: true
+        }
+    ]
+};};
+
+exp.entity_spec = make_spec();
+exp.register = function() {
+    var e = reg.entity;
+    e.register({type: 'passkeyconfig', spec: exp.entity_spec});
+};
+phases.on('registration', exp.register);
+
+return {};
+});

--- a/install/ui/test/data/i18n_messages.json
+++ b/install/ui/test/data/i18n_messages.json
@@ -555,6 +555,12 @@
                     "type_hotp": "Counter-based (HOTP)", 
                     "type_totp": "Time-based (TOTP)"
                 }, 
+                "passkeyconfig": {
+                    "options": _("Options"),
+                    "on": _("On"),
+                    "off": _("Off"),
+                    "default": _("Default"),
+                },
                 "permission": {
                     "add_custom_attr": "Add Custom Attribute", 
                     "attribute": "Attribute", 

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -1221,13 +1221,19 @@ class i18n_messages(Command):
                 "type_totp": _("Time-based (TOTP)"),
             },
             "passkey": {
-                "adder_title": "Add Passkey", 
-                "data_label": "Passkey", 
-                "deleter_content": "Do you want to remove passkey ${passkey}?", 
+                "adder_title": "Add Passkey",
+                "data_label": "Passkey",
+                "deleter_content": "Do you want to remove passkey ${passkey}?",
                 "deleter_title": "Remove Passkey",
                 "type_discoverable": "(discoverable) ",
                 "type_serverside": "(server-side) "
-            }, 
+            },
+            "passkeyconfig": {
+                "options": _("Options"),
+                "on": _("On"),
+                "off": _("Off"),
+                "default": _("Default"),
+            },
             "permission": {
                 "add_custom_attr": _("Add Custom Attribute"),
                 "attribute": _("Attribute"),


### PR DESCRIPTION
Add a "Passkey configuration" subtab in the "Policy" tab, showing the settings for passkeyconfig.

Related: https://pagure.io/freeipa/issue/9261

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>

![passkey](https://user-images.githubusercontent.com/21310191/208944241-62adcfc8-1b3e-47db-a4a3-2085927c7005.png)
