### PR TITLE
Passkey: extract the passkey from stdout

### DIFF
--- a/ipaclient/plugins/baseuser.py
+++ b/ipaclient/plugins/baseuser.py
@@ -3,7 +3,6 @@
 #
 
 import os
-import locale
 import logging
 import subprocess
 from ipaclient.frontend import MethodOverride
@@ -80,14 +79,19 @@ class baseuser_add_passkey(MethodOverride):
                     cmd.append(str(require_verif).lower())
 
                 logger.debug("Executing command: %s", cmd)
-                subp = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-                stdout, _stderr = subp.communicate(None)
+                passkey = None
+                with subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                      bufsize=1,
+                                      universal_newlines=True) as subp:
+                    for line in subp.stdout:
+                        if line.startswith("passkey:"):
+                            passkey = line.strip()
+                        else:
+                            print(line.strip())
 
                 if subp.returncode != 0:
                     raise errors.NotFound(reason="Failed to generate passkey")
 
-                passkey = stdout.decode(locale.getpreferredencoding(),
-                                        errors='replace').strip()
                 args = (args[0], [passkey])
 
         return super(baseuser_add_passkey, self).forward(*args, **options)


### PR DESCRIPTION
SSSD's command passkey_child was previously using stderr to print the following messages:
PIN required.
Please touch the device.
but switched to stdout instead in the commit
https://github.com/SSSD/sssd/commit/6b0d175f8fad63c9c41e0b990c4a5632e96cc3f7

Stdout was used only for displaying the generated passkey.

This means that ipa user-add-passkey --register now must read stdout line by line and print only the messages that the user needs to see (all lines except the one containing the passkey).