### PR TITLE
Passkey: add a weak dependency on sssd-passkey

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -708,6 +708,9 @@ Recommends: libsss_sudo
 Recommends: sudo
 Requires: (libsss_sudo if sudo)
 
+# Passkey support
+Recommends: sssd-passkey
+
 Provides: %{alt_name}-client = %{version}
 Conflicts: %{alt_name}-client
 Obsoletes: %{alt_name}-client < %{version}


### PR DESCRIPTION
The package sssd-passkey provides the executable
/usr/libexec/sssd/passkey_child
which is not mandatory but recommended.

Add a weak dependency from ipa client package on sssd-passkey.

TBD: when a new version of sssd is released with passkey support, bump the SSSD version.

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>