### PR TITLE
passkeyconfig: require-user-verification is a boolean

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -3776,7 +3776,7 @@ args: 0,8,3
 option: Str('addattr*', cli_name='addattr')
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Str('delattr*', cli_name='delattr')
-option: StrEnum('iparequireuserverification?', autofill=False, cli_name='require_user_verification', values=[u'on', u'off', u'default'])
+option: Bool('iparequireuserverification?', autofill=False, cli_name='require_user_verification')
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
 option: Flag('rights', autofill=True, default=False)
 option: Str('setattr*', cli_name='setattr')

--- a/doc/api/passkeyconfig_mod.md
+++ b/doc/api/passkeyconfig_mod.md
@@ -12,8 +12,7 @@ No arguments.
  * Default: False
 * raw : :ref:`Flag<Flag>` **(Required)**
  * Default: False
-* iparequireuserverification : :ref:`StrEnum<StrEnum>`
- * Values: ('on', 'off', 'default')
+* iparequireuserverification : :ref:`Bool<Bool>`
 * setattr : :ref:`Str<Str>`
 * addattr : :ref:`Str<Str>`
 * delattr : :ref:`Str<Str>`

--- a/doc/designs/passkeys.md
+++ b/doc/designs/passkeys.md
@@ -43,10 +43,10 @@ a Kerberos ticket can be obtained and used against those services later.
 
 The administrator is able to specify common settings that will apply:
 
-- require user verification during authentication (On/Off/Default):
-  - On: require user verification during authentication (PIN for instance).
-  - Off: do not require user verification during authentication.
-  - Default: fallback to the passkey’s default behavior.
+- require user verification during authentication (True/False):
+  - True: require user verification during authentication (PIN for instance).
+  - False: do not require user verification during authentication.
+The default value is True.
 
 ### Registration of credentials
 
@@ -113,13 +113,13 @@ objectclass: top
 objectclass: nsContainer
 objectclass: ipapasskeyconfigObject
 cn: passkeyconfig
-ipaRequireUserVerification: default
+ipaRequireUserVerification: True
 ```
 
 The object class allows a single attribute, require user verification,
-which is mandatory, single valued, and stores a string (on, off, default).
+which is mandatory, single valued, and stores a boolean (TURE, FALSE).
 The LDAP entry is added when IPA server is installed or when the server is
-upgraded to a version supporting passkeys.
+upgraded to a version supporting passkeys, with a default value = TRUE.
 
 ### Storage of the passkey mapping
 
@@ -183,7 +183,7 @@ settings or another user's passkeys.
 
 New objectclass and attribute for the passkey configuration object:
 ```
-attributeTypes: ( 2.16.840.1.113730.3.8.24.26 NAME 'ipaRequireUserVerification' DESC 'require passkey user verification' SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'IPA v4.10')
+attributeTypes: ( 2.16.840.1.113730.3.8.24.26 NAME 'ipaRequireUserVerification' DESC 'require passkey user verification' EQUALITY booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE X-ORIGIN 'IPA v4.10')
 objectclasses: ( 2.16.840.1.113730.3.8.24.8 NAME 'ipaPasskeyConfigObject' DESC 'IPA passkey global config options' AUXILIARY MUST ipaRequireUserVerification X-ORIGIN 'IPA v4.10')
 ```
 
@@ -224,7 +224,7 @@ using the WebUI will not be part of the original implementation.
 | --- | ----- | --- |
 | **Passkey configuration** | | |
 | passkeyconfig-show | | This command displays the Passkey settings |
-| passkeyconfig-mod | --require-user-verification=['on', 'off', 'default'] | This command modifies the Passkey settings |
+| passkeyconfig-mod | --require-user-verification=BOOL | This command modifies the Passkey settings |
 | **User Mapping** | | |
 | user-add-passkey | LOGIN [PASSKEY...] | This command does not require the device to be inserted and can directly add the mapping data, obtained through another mean (for instance through sssctl passkey-exec --register) |
 | user-add-passkey | LOGIN --register [--cose-type=['es256', 'rs256', 'eddsa']] [--require-user-verification=BOOL] | This command requires the insertion of the device, performs the registration with the specified cose type + user verification requirement, and adds the mapping data to the user entry |

--- a/install/share/60basev4.ldif
+++ b/install/share/60basev4.ldif
@@ -33,7 +33,7 @@ attributeTypes: (2.16.840.1.113730.3.8.23.25 NAME 'ipaIdpKeysEndpoint' DESC 'Ide
 objectClasses: (2.16.840.1.113730.3.8.24.6 NAME 'ipaIdP' SUP top STRUCTURAL DESC 'Identity Provider Configuration' MUST ( cn ) MAY ( ipaIdpDevAuthEndpoint $ ipaIdpAuthEndpoint $ ipaIdpTokenEndpoint $ ipaIdpUserInfoEndpoint $ ipaIdpKeysEndpoint $ ipaIdpClientId $ description $ ipaIdpClientSecret $ ipaIdpScope $ ipaIdpIssuerURL $ ipaIdpSub ) X-ORIGIN 'IPA v4.9' )
 objectClasses: (2.16.840.1.113730.3.8.24.7 NAME 'ipaIdpUser' SUP top AUXILIARY DESC 'User from an external Identity Provider ' MAY ( ipaIdpConfigLink $ ipaIdpSub ) X-ORIGIN 'IPA v4.9' )
 ### Passkey support
-attributeTypes: ( 2.16.840.1.113730.3.8.24.26 NAME 'ipaRequireUserVerification' DESC 'require passkey user verification' SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'IPA v4.10')
+attributeTypes: ( 2.16.840.1.113730.3.8.24.26 NAME 'ipaRequireUserVerification' DESC 'require passkey user verification' EQUALITY booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE X-ORIGIN 'IPA v4.10')
 attributeTypes: ( 2.16.840.1.113730.3.8.24.27 NAME 'ipapasskey' DESC 'Passkey mapping' EQUALITY caseExactMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'IPA v4.10' )
 objectclasses: ( 2.16.840.1.113730.3.8.24.8 NAME 'ipaPasskeyConfigObject' DESC 'IPA passkey global config options' AUXILIARY MUST ipaRequireUserVerification X-ORIGIN 'IPA v4.10')
 objectclasses: ( 2.16.840.1.113730.3.8.24.9 NAME 'ipaPasskeyUser' DESC 'IPA passkey user' AUXILIARY MAY ipapasskey X-ORIGIN 'IPA v4.10')

--- a/install/ui/src/freeipa/passkeyconfig.js
+++ b/install/ui/src/freeipa/passkeyconfig.js
@@ -29,23 +29,8 @@ return {
                     label: '@i18n:objects.passkeyconfig.options',
                     fields: [
                         {
-                            $type: 'radio',
-                            name: 'iparequireuserverification',
-                            default_value: 'default',
-                            options: [
-                                {
-                                    value: 'on',
-                                    label: '@i18n:objects.passkeyconfig.on'
-                                },
-                                {
-                                    value: 'off',
-                                    label: '@i18n:objects.passkeyconfig.off'
-                                },
-                                {
-                                    value: 'default',
-                                    label: '@i18n:objects.passkeyconfig.default'
-                                }
-                            ]
+                            $type: 'checkbox',
+                            name: 'iparequireuserverification'
                         }
                     ]
                 }

--- a/install/ui/test/data/i18n_messages.json
+++ b/install/ui/test/data/i18n_messages.json
@@ -556,10 +556,7 @@
                     "type_totp": "Time-based (TOTP)"
                 }, 
                 "passkeyconfig": {
-                    "options": _("Options"),
-                    "on": _("On"),
-                    "off": _("Off"),
-                    "default": _("Default"),
+                    "options": _("Options")
                 },
                 "permission": {
                     "add_custom_attr": "Add Custom Attribute", 

--- a/install/updates/73-passkey.update
+++ b/install/updates/73-passkey.update
@@ -3,7 +3,7 @@ dn: cn=passkeyconfig,cn=etc,$SUFFIX
 default:objectclass: top
 default:objectclass: nscontainer
 default:objectclass: ipaPasskeyConfigObject
-default:ipaRequireUserVerification: default
+default:ipaRequireUserVerification: TRUE
 
 # Passkey Administrators
 dn: cn=Passkey Administrators,cn=privileges,cn=pbac,$SUFFIX

--- a/ipaserver/plugins/internal.py
+++ b/ipaserver/plugins/internal.py
@@ -1233,10 +1233,7 @@ class i18n_messages(Command):
                 "type_serverside": "(server-side) "
             },
             "passkeyconfig": {
-                "options": _("Options"),
-                "on": _("On"),
-                "off": _("Off"),
-                "default": _("Default"),
+                "options": _("Options")
             },
             "permission": {
                 "add_custom_attr": _("Add Custom Attribute"),

--- a/ipaserver/plugins/passkeyconfig.py
+++ b/ipaserver/plugins/passkeyconfig.py
@@ -5,7 +5,7 @@
 import logging
 
 from ipalib import api
-from ipalib.parameters import StrEnum
+from ipalib.parameters import Bool
 from ipalib.plugable import Registry
 from .baseldap import (
     LDAPObject,
@@ -34,7 +34,7 @@ EXAMPLES:
    ipa passkeyconfig-show
 """) + _("""
  Modify the Passkey configuration to always require user verification:
-   ipa passkeyconfig-mod --require-user-verification=on
+   ipa passkeyconfig-mod --require-user-verification=TRUE
 """)
 
 register = Registry()
@@ -53,12 +53,11 @@ class passkeyconfig(LDAPObject):
     label_singular = _('Passkey Configuration')
 
     takes_params = (
-        StrEnum(
+        Bool(
             'iparequireuserverification',
             cli_name="require_user_verification",
             label=_("Require user verification"),
             doc=_('Require user verification during authentication'),
-            values=('on', 'off', 'default'),
         ),
     )
 

--- a/ipatests/test_xmlrpc/test_passkey_plugin.py
+++ b/ipatests/test_xmlrpc/test_passkey_plugin.py
@@ -18,7 +18,7 @@ def passkey_config(request, xmlrpc_setup):
 
 
 class TestPasskeyconfig(XMLRPC_test):
-    @pytest.mark.parametrize("userverification", ['on', 'off', 'default'])
+    @pytest.mark.parametrize("userverification", [False, True])
     def test_config_mod(self, passkey_config, userverification):
         """
         Test the passkeyconfig-mod CLI with possible values for
@@ -38,7 +38,7 @@ class TestPasskeyconfig(XMLRPC_test):
             updates={'iparequireuserverification': 'Invalid'}
         )
 
-        with pytest.raises(errors.ValidationError):
+        with pytest.raises(errors.ConversionError):
             cmd()
 
     def test_config_show(self, passkey_config):


### PR DESCRIPTION
ipa passkeyconfig-mod now accepts Boolean values for --require-user-verification

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>