### PR TITLE
passkey: adjust selinux security context for passkey_child

### DIFF
--- a/selinux/ipa.fc
+++ b/selinux/ipa.fc
@@ -9,6 +9,7 @@
 /usr/libexec/ipa-otpd		--	gen_context(system_u:object_r:ipa_otpd_exec_t,s0)
 /usr/libexec/ipa/ipa-otpd		--	gen_context(system_u:object_r:ipa_otpd_exec_t,s0)
 /usr/libexec/sssd/oidc_child 	-- gen_context(system_u:object_r:ipa_otpd_exec_t,s0)
+/usr/libexec/sssd/passkey_child 	-- gen_context(system_u:object_r:ipa_otpd_exec_t,s0)
 
 /usr/libexec/ipa/ipa-ods-exporter	--	gen_context(system_u:object_r:ipa_ods_exporter_exec_t,s0)
 


### PR DESCRIPTION
SSSD ships passkey_child binary in /usr/libexec/sssd and it needs the same security context as /usr/libexec/sssd/oidc_child (ipa_otpd_exec_t type).

Add the context in the SELinux policy provided by IPA.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2169438