### PR TITLE
ipatests: disable dnssec validation in tests using dnf

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -61,14 +61,26 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_installation_TestInstallMaster:
     requires: [fedora-latest/build]
-    priority: 50
+    priority: 100
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_installation.py::TestInstallMaster
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest/test_advise:
+    requires: [fedora-latest/build]
+    priority: 100
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_advise.py
         template: *ci-master-latest
         timeout: 3600
         topology: *master_1repl_1client

--- a/ipatests/test_integration/test_advise.py
+++ b/ipatests/test_integration/test_advise.py
@@ -50,6 +50,16 @@ class TestAdvice(IntegrationTest):
     num_replicas = 0
     num_clients = 1
 
+    @classmethod
+    def install(cls, mh):
+        # Install without dnssec validation because the test is
+        # calling dnf install on the client and mirrors.fedoraproject.org
+        # has a broken trust chain
+        tasks.install_master(
+            cls.master, setup_dns=True, extra_args=['--no-dnssec-validation']
+        )
+        tasks.install_client(cls.master, cls.clients[0])
+
     def execute_advise(self, host, advice_id, *args):
         # ipa-advise script is only available on a server
         tasks.kinit_admin(self.master)

--- a/ipatests/test_integration/test_installation.py
+++ b/ipatests/test_integration/test_installation.py
@@ -1262,7 +1262,10 @@ class TestInstallMaster(IntegrationTest):
             tasks.uninstall_packages(self.master, [package_name])
             reinstall = True
         try:
-            tasks.install_master(self.master)
+            # Disable dnssec-validation as the test is calling dnf install
+            # and mirrors.fedoraproject.org have a broken trust chain
+            tasks.install_master(self.master,
+                                 extra_args=['--no-dnssec-validation'])
         finally:
             if reinstall:
                 tasks.install_packages(self.master, [package_name])


### PR DESCRIPTION
The 2 following tests rely on dnf install and use
mirrors.fedoraproject.org which has a broken trust chain.
Disable dnssec validation so that dnf succeeds.

Signed-off-by: Florence Blanc-Renaud <flo@redhat.com>