### PR TITLE
Installation: use absolute DNS hostname to find IP addresses

### DIFF
--- a/ipaserver/install/installutils.py
+++ b/ipaserver/install/installutils.py
@@ -522,7 +522,8 @@ def resolve_rrsets_nss(fqdn):
 
 
 def get_server_ip_address(host_name, unattended, setup_dns, ip_addresses):
-    hostaddr = resolve_ip_addresses_nss(host_name)
+    absolute_hostname = DNSName.from_text(host_name).make_absolute().to_text()
+    hostaddr = resolve_ip_addresses_nss(absolute_hostname)
     if hostaddr.intersection(
             {ipautil.UnsafeIPAddress(ip) for ip in ['127.0.0.1', '::1']}):
         print("The hostname resolves to the localhost address (127.0.0.1/::1)", file=sys.stderr)


### PR DESCRIPTION
During ipa server installation, the IP addresses are found by calling get_server_ip_address(host_name). This method internally calls resolve_ip_addresses_nss but returns only IPv4 addresses if the host name is not an absolute DNS name (ending with a dot). This list of IP addresses is later used to create the DNS records for the server (and is missing the AAAA records).

Later on, the DNS server is setup and the records for ipa-ca are added, using the IP addresses returned by resolve_ip_addresses_nss, but this time called with an absolute DNS name, thus containing both IPv4 and IPv6 addresses.

This results in an inconsistent list of DNS records as the server has only IPv4 addresses but ipa-ca has both IPv4 and IPv6 addresses. The problem is reported by ipa-healthcheck.

Fix the problem by using an absolute DNS name in the first step, so that both IPv4 and IPv6 addresses are found and A and AAAA records are created for the server.