### PR TITLE
ipatests: add extensions to server certificates for CAless mode

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -51,12 +51,13 @@ topologies:
     memory: 12096
 
 jobs:
-  fedora-latest/build:
+  pki-fedora/build:
     requires: []
     priority: 100
     job:
       class: Build
       args:
+        copr: '@pki/master'
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
@@ -65,14 +66,16 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
-    requires: [fedora-latest/build]
+  pki-fedora/test_caless_TestServerReplicaCALessToCAFull:
+    requires: [pki-fedora/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        build_url: '{pki-fedora/build_url}'
+        update_packages: True
+        copr: '@pki/master'
+        test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 5400
+        topology: *master_1repl


### PR DESCRIPTION
[ipatests: add extensions to server certificates for CAless mode](https://github.com/flo-renaud/freeipa/commit/6831a80d052e67e3c3eda9bcca00fd845c33fce4)

When installing the server in CA less mode, the tests generate
server certificates but some extensions were missing.
Add Autority Key Identifier, KeyUsage and Extended Key Usage.

Related: https://github.com/dogtagpki/pki/issues/5051