### PR TITLE
DNS over TLS: use system trust store

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/client/share/unbound.conf.template
+++ b/client/share/unbound.conf.template
@@ -1,5 +1,5 @@
 server:
-    tls-cert-bundle: $TLS_CERT_BUNDLE_PATH
+    tls-system-cert: yes
     tls-upstream: yes
     interface: 127.0.0.55
     log-servfail: yes

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1403,6 +1403,17 @@ if [ $1 -gt 1 ] ; then
             fi
         fi
     fi
+
+    UNBOUND_CFG=/etc/unbound/conf.d/zzz-ipa.conf
+    if [ -f "$UNBOUND_CFG" -a $restore -ge 2 ]; then
+        # The client has been configured for Dot
+        # replace the line tls-cert-bundle: /etc/pki/tls/certs/ca-bundle.crt
+        # with tls-system-cert: yes
+        # See https://fedoraproject.org/wiki/Changes/droppingOfCertPemFile
+        if grep -E -q 'tls-cert-bundle: \/etc\/pki\/tls\/certs\/ca-bundle.crt'  $UNBOUND_CFG 2>/dev/null; then
+            sed -E --in-place=.orig 's/tls-cert-bundle: \/etc\/pki\/tls\/certs\/ca-bundle.crt/tls-system-cert: yes/' $UNBOUND_CFG
+        fi
+    fi
 fi
 
 

--- a/ipaclient/install/client.py
+++ b/ipaclient/install/client.py
@@ -1692,8 +1692,6 @@ def client_dns(server, hostname, options, statestore):
             paths.UNBOUND_CONF_SRC,
             paths.UNBOUND_CONF,
             dict(
-                TLS_CERT_BUNDLE_PATH=os.path.join(
-                    paths.OPENSSL_CERTS_DIR, "ca-bundle.crt"),
                 FORWARD_ADDRS=forward_addr,
                 MODULE_CONFIG_ITERATOR=module_config_iterator
             )

--- a/ipaserver/install/dns.py
+++ b/ipaserver/install/dns.py
@@ -152,8 +152,6 @@ def _setup_dns_over_tls(options):
         paths.UNBOUND_CONF_SRC,
         paths.UNBOUND_CONF,
         dict(
-            TLS_CERT_BUNDLE_PATH=os.path.join(
-                paths.OPENSSL_CERTS_DIR, "ca-bundle.crt"),
             FORWARD_ADDRS="\n".join(forward_addrs),
             MODULE_CONFIG_ITERATOR=module_config_iterator
         )

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -55,7 +55,8 @@ topologies:
     memory: 14750
 
 jobs:
-  fedora-latest/build:
+
+  fedora-rawhide/build:
     requires: []
     priority: 100
     job:
@@ -63,20 +64,21 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-latest
-          name: freeipa/ci-master-f42
-          version: 0.0.4
+        template: &ci-master-frawhide
+          name: freeipa/ci-master-frawhide
+          version: 0.9.1
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
-    requires: [fedora-latest/build]
-    priority: 50
+  fedora-rawhide/test_edns:
+    requires: [fedora-rawhide/build]
+    priority: 100
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
-        template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_edns.py
+        template: *ci-master-frawhide
+        timeout: 14400
+        topology: *master_2repl_1client


### PR DESCRIPTION
When a client or server is configured with DoT, the installer
creates /etc/unbound/conf.d/zzz-ipa.conf with
    tls-cert-bundle: /etc/pki/tls/certs/ca-bundle.crt

This certificate bundle does not exist any more in fedora 43+
(https://fedoraproject.org/wiki/Changes/droppingOfCertPemFile)
and the missing file prevents unbound service from starting.

The configuration should rather set
    tls-system-cert: yes
in order to rely on the systemwide trust store.

The upgrade is also handled by this change.

Fixes: https://pagure.io/freeipa/issue/9838