### PR TITLE
ipatests: fix TestIpaClientAutomountDiscovery

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -69,14 +69,15 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/nfs_automountdiscovery:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_nfs.py::TestIpaClientAutomountDiscovery
+        trusted_domain: True
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *ipa_ipa_trust


### PR DESCRIPTION
When executed in IDM-CI the test fails because the file
/etc/resolv.conf is overwritten by Networkmanager.
Use the methods provided by the tasks module to modify
resolver configuration.