### PR TITLE
F44

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -42,8 +42,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f43
-          version: 0.0.2
+          name: freeipa/ci-master-f44
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -58,8 +58,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f43
-          version: 0.0.2
+          name: freeipa/ci-master-f44
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -39,8 +39,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f43
-          version: 0.0.2
+          name: freeipa/ci-master-f41
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_pki.yaml
+++ b/ipatests/prci_definitions/nightly_latest_pki.yaml
@@ -44,7 +44,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
           name: freeipa/ci-master-f43
-          version: 0.0.2
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_selinux.yaml
@@ -58,8 +58,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f43
-          version: 0.0.2
+          name: freeipa/ci-master-f44
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_sssd.yaml
+++ b/ipatests/prci_definitions/nightly_latest_sssd.yaml
@@ -47,8 +47,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f43
-          version: 0.0.2
+          name: freeipa/ci-master-f44
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -59,8 +59,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f43
-          version: 0.0.2
+          name: freeipa/ci-master-f44
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing_selinux.yaml
@@ -59,8 +59,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f43
-          version: 0.0.2
+          name: freeipa/ci-master-f44
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -58,8 +58,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-previous
-          name: freeipa/ci-master-f42
-          version: 0.0.9
+          name: freeipa/ci-master-f43
+          version: 0.0.2
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -64,8 +64,8 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-master-latest
-          name: freeipa/ci-master-f43
-          version: 0.0.2
+          name: freeipa/ci-master-f44
+          version: 0.0.1
         timeout: 1800
         topology: *build
 

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -69,14 +69,30 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/simple_replication:
     requires: [fedora-latest/build]
-    priority: 50
+    priority: 100
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_simple_replication.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl
+
+  fedora-latest/test_webui_general:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: >-
+          test_webui/test_loginscreen.py
+          test_webui/test_misc_cases.py
+          test_webui/test_navigation.py
+          test_webui/test_translation.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *ipaserver


### PR DESCRIPTION
Fedora 44 is already available and Fedora 42 will be EOL
Wed 2026-05-13 according to Fedora schedule:
https://fedorapeople.org/groups/schedule/f-42/f-42-all-tasks.html

Start testing on fedora 43 and fedora 44.

Fixes: IDM-6258