### PR TITLE
CI: switch testing from fedora 43 to fedora 44

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/gating.yaml
+++ b/ipatests/prci_definitions/gating.yaml
@@ -42,7 +42,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-13-latest
-          name: freeipa/ci-ipa-4-13-f43
+          name: freeipa/ci-ipa-4-13-f44
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_ipa-4-13_latest.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-13_latest.yaml
@@ -58,7 +58,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-13-latest
-          name: freeipa/ci-ipa-4-13-f43
+          name: freeipa/ci-ipa-4-13-f44
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/nightly_ipa-4-13_latest_selinux.yaml
+++ b/ipatests/prci_definitions/nightly_ipa-4-13_latest_selinux.yaml
@@ -58,7 +58,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-13-latest
-          name: freeipa/ci-ipa-4-13-f43
+          name: freeipa/ci-ipa-4-13-f44
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -64,7 +64,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &ci-ipa-4-13-latest
-          name: freeipa/ci-ipa-4-13-f43
+          name: freeipa/ci-ipa-4-13-f44
           version: 0.0.1
         timeout: 1800
         topology: *build

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -69,14 +69,30 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest-ipa-4-13/temp_commit:
+  fedora-latest-ipa-4-13/simple_replication:
     requires: [fedora-latest-ipa-4-13/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest-ipa-4-13/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_simple_replication.py
         template: *ci-ipa-4-13-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl
+
+  fedora-latest-ipa-4-13/test_webui_general:
+    requires: [fedora-latest-ipa-4-13/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-latest-ipa-4-13/build_url}'
+        test_suite: >-
+          test_webui/test_loginscreen.py
+          test_webui/test_misc_cases.py
+          test_webui/test_navigation.py
+          test_webui/test_translation.py
+        template: *ci-ipa-4-13-latest
+        timeout: 3600
+        topology: *ipaserver


### PR DESCRIPTION
Fedora 44 is already available and Fedora 42 will be EOL Wed 2026-05-13
according to Fedora schedule:
https://fedorapeople.org/groups/schedule/f-42/f-42-all-tasks.html

Start testing on fedora 44.

Fixes: IDM-6259