### PR TITLE
ipa-restore: do not follow symlinks when calling chown

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -94,12 +94,13 @@ def recursive_chown(path, uid, gid):
     '''
     Change ownership of all files and directories in a path.
     '''
-    for root, dirs, files in os.walk(path):
+    for root, dirs, files in os.walk(path, topdown=True, followlinks=False):
+        dirs = [d for d in dirs if not os.path.islink(os.path.join(root, d))]
         for dir in dirs:
-            os.chown(os.path.join(root, dir), uid, gid)
+            os.chown(os.path.join(root, dir), uid, gid, follow_symlinks=False)
             os.chmod(os.path.join(root, dir), 0o750)
         for file in files:
-            os.chown(os.path.join(root, file), uid, gid)
+            os.chown(os.path.join(root, file), uid, gid, follow_symlinks=False)
             os.chmod(os.path.join(root, file), 0o640)
 
 
@@ -386,12 +387,9 @@ class Restore(admintool.AdminTool):
 
         # Temporary directory for decrypting files before restoring
         self.top_dir = tempfile.mkdtemp("ipa")
-        constants.DS_USER.chown(self.top_dir)
-        os.chmod(self.top_dir, 0o750)
+        os.chmod(self.top_dir, 0o700)
         self.dir = os.path.join(self.top_dir, "ipa")
-        os.mkdir(self.dir)
-        os.chmod(self.dir, 0o750)
-        constants.DS_USER.chown(self.dir)
+        os.mkdir(self.dir, 0o700)
 
         logger.info("Temporary setting umask to 022")
         old_umask = os.umask(0o022)
@@ -868,10 +866,10 @@ class Restore(admintool.AdminTool):
                 ]
         run(args, cwd=self.dir)
 
-        constants.DS_USER.chown(self.top_dir)
         recursive_chown(
             self.dir, constants.DS_USER.uid, constants.DS_USER.pgid
         )
+        constants.DS_USER.chown(self.top_dir)
 
         if encrypt:
             # We can remove the decoded tarball

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -69,14 +69,170 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_backup_and_restore.py::TestUserRootFilesOwnershipPermission
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest/test_backup_and_restore_TestBackupAndRestore:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestore
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest/test_backup_and_restore_TestBackupAndRestoreWithDNSSEC:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNSSEC
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest/test_backup_and_restore_TestBackupReinstallRestoreWithDNSSEC:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNSSEC
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest/test_backup_and_restore_TestBackupAndRestoreWithDNS:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNS
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest/test_backup_and_restore_TestBackupReinstallRestoreWithDNS:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNS
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest/test_backup_and_restore_TestBackupAndRestoreWithKRA:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest/test_backup_and_restore_TestBackupAndRestoreWithReplica:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_2repl_1client
+
+  fedora-latest/test_backup_and_restore_TestBackupAndRestoreDMPassword:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreDMPassword
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest/test_backup_and_restore_TestReplicaInstallAfterRestore:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_2repl_1client
+
+  fedora-latest/test_backup_and_restore_TestBackupRoles:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupRoles
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  fedora-latest/test_hsm_TestHSMBackupRestore:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_hsm.py::TestHSMBackupRestore
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl
+
+  fedora-latest/test_IPAMigrateBackupRestore:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_ipa_ipa_migration.py::TestIPAMigratewithBackupRestore
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_2repl_1client


### PR DESCRIPTION
ipa-restore creates:
- a temp directory /tmp/xxxipa owned by dirsrv (0o750)
- a temp subdirectory /tmp/xxxipa/ipa owned by dirsv (0o750)
and extracts the backup in /tmp/xxxipa/ipa.

Use 0o700 instead of 0o750.
Change ownership of the top directory as late as possible (after
the files have been extracted).

ipa-restore modifies the files ownership in /tmp/xxxipa/ipa
to dirsrv user/group.
Do not follow symlinks for this operation.