### PR TITLE
webui tests: add xfail for known issues

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -69,14 +69,28 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_webui_users:
     requires: [fedora-latest/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunWebuiTests
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: >-
+          test_webui/test_group.py
+          test_webui/test_user.py
+        template: *ci-master-latest
+        timeout: 4800
+        topology: *ipaserver
+
+  fedora-latest/test_webui_host:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunWebuiTests
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_webui/test_host.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *ipaserver

--- a/ipatests/test_webui/test_host.py
+++ b/ipatests/test_webui/test_host.py
@@ -254,6 +254,10 @@ class test_host(host_tasks):
         self.delete_record(self.pkey, self.data.get('del'))
 
     @screenshot
+    @pytest.mark.xfail(
+        reason="https://codeberg.org/freeipa/freeipa/issues/9928",
+        strict=True
+    )
     def test_arbitrary_certificates(self):
         """
         Test managing host arbitrary certificate.
@@ -686,6 +690,10 @@ class test_host(host_tasks):
         self.delete(ENTITY, [self.data2])
 
     @screenshot
+    @pytest.mark.xfail(
+        reason="https://codeberg.org/freeipa/freeipa/issues/9928",
+        strict=True
+    )
     def test_negative_cert(self):
         """ Test negative CSR """
         self.init_app()

--- a/ipatests/test_webui/test_user.py
+++ b/ipatests/test_webui/test_user.py
@@ -353,6 +353,10 @@ class test_user(user_tasks):
         self.delete_record(user.PKEY, user.DATA.get('del'))
 
     @screenshot
+    @pytest.mark.xfail(
+        reason="https://codeberg.org/freeipa/freeipa/issues/9928",
+        strict=True
+    )
     def test_certificate_serial(self):
         """Test long certificate serial no
         Long certificate serial no were shown in scientific notation


### PR DESCRIPTION
The following tests are failing because of issue 9928:
- test_webui/test_user.py::test_user::test_certificate_serial
- test_webui/test_host.py::test_host::test_arbitrary_certificates
- test_webui/test_host.py::test_host::test_negative_cert

Mark them with an xfail annotation until the ticket is solved.

Related: https://codeberg.org/freeipa/freeipa/issues/9928