### PR TITLE
ipatests: add xfail for NTLM authentication tests

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -69,14 +69,67 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_smb:
     requires: [fedora-latest/build]
     priority: 50
     job:
-      class: RunPytest
+      class: RunADTests
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_smb.py
         template: *ci-master-latest
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 7200
+        topology: *ad_master_2client
+
+  fedora-rawhide/build:
+    requires: []
+    priority: 100
+    job:
+      class: Build
+      args:
+        git_repo: '{git_repo}'
+        git_refspec: '{git_refspec}'
+        template: &ci-master-frawhide
+          name: freeipa/ci-master-frawhide
+          version: 0.10.1
+        timeout: 1800
+        topology: *build
+
+  fedora-rawhide/test_smb:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_smb.py
+        template: *ci-master-frawhide
+        timeout: 7200
+        topology: *ad_master_2client
+
+  fedora-previous/build:
+    requires: []
+    priority: 100
+    job:
+      class: Build
+      args:
+        git_repo: '{git_repo}'
+        git_refspec: '{git_refspec}'
+        template: &ci-master-previous
+          name: freeipa/ci-master-f43
+          version: 0.0.2
+        timeout: 1800
+        topology: *build
+
+  fedora-previous/test_smb:
+    requires: [fedora-previous/build]
+    priority: 50
+    job:
+      class: RunADTests
+      args:
+        build_url: '{fedora-previous/build_url}'
+        test_suite: test_integration/test_smb.py
+        template: *ci-master-previous
+        timeout: 7200
+        topology: *ad_master_2client

--- a/ipatests/test_integration/test_smb.py
+++ b/ipatests/test_integration/test_smb.py
@@ -20,6 +20,7 @@ from ipatests.pytest_ipa.integration import tasks
 from ipaplatform.osinfo import osinfo
 from ipaplatform.paths import paths
 from ipatests.pytest_ipa.integration import skip_if_fips
+from ipatests.util import xfail_context
 
 
 def wait_smbd_functional(host):
@@ -417,6 +418,22 @@ class TestSMB(IntegrationTest):
             self.cleanup_mount(mountpoint)
             self.smbserver.run_command(['rm', '-f', test_file_server_path])
 
+    def ntlm_failure(self):
+        """
+        Check the samba version and return true if the NTLM
+        authentication is expected to fail with this version.
+        """
+        result = self.smbclient.run_command(["smbclient", "-V"]).stdout_text
+        # Output has the format: Version 4.23.7
+        version = result.split()[1]
+        samba = tasks.parse_version(version)
+        # Versions 4.23.9 and above, 4.24.2 and above fail the test
+        if tasks.parse_version('4.23.9') <= samba < tasks.parse_version('4.24'):
+            return True
+        elif samba >= tasks.parse_version('4.24.2'):
+            return True
+        return False
+
     @skip_if_fips()
     def test_ntlm_authentication_with_auto_domain(self):
         """Repeatedly try to authenticate with username and password with
@@ -432,7 +449,11 @@ class TestSMB(IntegrationTest):
             password=self.ipa_user1_password
         )
 
-        self.check_repeated_smb_mount(mount_options)
+        with xfail_context(
+            self.ntlm_failure,
+            reason="https://codeberg.org/freeipa/freeipa/issues/9999"
+        ):
+            self.check_repeated_smb_mount(mount_options)
 
     @skip_if_fips()
     def test_ntlm_authentication_with_upn_with_lowercase_domain(self):
@@ -443,7 +464,11 @@ class TestSMB(IntegrationTest):
             password=self.ipa_user1_password,
             domain=self.master.domain.name.lower()
         )
-        self.check_repeated_smb_mount(mount_options)
+        with xfail_context(
+            self.ntlm_failure,
+            reason="https://codeberg.org/freeipa/freeipa/issues/9999"
+        ):
+            self.check_repeated_smb_mount(mount_options)
 
     @skip_if_fips()
     def test_ntlm_authentication_with_upn_with_uppercase_domain(self):
@@ -454,7 +479,11 @@ class TestSMB(IntegrationTest):
             password=self.ipa_user1_password,
             domain=self.master.domain.name.upper()
         )
-        self.check_repeated_smb_mount(mount_options)
+        with xfail_context(
+            self.ntlm_failure,
+            reason="https://codeberg.org/freeipa/freeipa/issues/9999"
+        ):
+            self.check_repeated_smb_mount(mount_options)
 
     def test_uninstall_samba(self):
         self.smbserver.run_command(['ipa-client-samba', '--uninstall', '-U'])


### PR DESCRIPTION
With samba >= 4.23.9 and samba >= 4.24.2, the following tests
are failing:
- test_ntlm_authentication_with_auto_domain
- test_ntlm_authentication_with_upn_with_lowercase_domain
- test_ntlm_authentication_with_upn_with_uppercase_domain

Add an xfail annotation until the issue is solved.

Related: https://codeberg.org/freeipa/freeipa/issues/9999