### PR TITLE
ipatests: override uninstall in TestHSMcertFix

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -69,14 +69,38 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-latest/temp_commit:
+  fedora-latest/test_hsm_TestHSMcertFix:
     requires: [fedora-latest/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_hsm.py::TestHSMcertFix
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_1repl
+
+  fedora-latest/test_hsm_TestHSMcertFixKRA:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_hsm.py::TestHSMcertFixKRA
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  fedora-latest/test_hsm_TestHSMcertFixReplica:
+    requires: [fedora-latest/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-latest/build_url}'
+        test_suite: test_integration/test_hsm.py::TestHSMcertFixReplica
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/test_integration/test_hsm.py
+++ b/ipatests/test_integration/test_hsm.py
@@ -650,6 +650,13 @@ class TestHSMcertFix(BaseHSMTest):
 
     master_with_dns = False
 
+    @classmethod
+    def uninstall(cls, mh):
+        # As the fixture expire_cert_critical already uninstalls the master,
+        # skip this step in uninstall
+        check_version(cls.master)
+        delete_hsm_token([cls.master] + cls.replicas, cls.token_name)
+
     def test_hsm_renew_expired_cert_on_master(self, expire_cert_critical):
         check_version(self.master)
         expire_cert_critical(self.master)
@@ -674,6 +681,13 @@ class TestHSMcertFixKRA(BaseHSMTest):
 
     master_with_dns = False
     master_with_kra = True
+
+    @classmethod
+    def uninstall(cls, mh):
+        # As the fixture expire_cert_critical already uninstalls the master,
+        # skip this step in uninstall
+        check_version(cls.master)
+        delete_hsm_token([cls.master] + cls.replicas, cls.token_name)
 
     def test_hsm_renew_expired_cert_with_kra(self, expire_cert_critical):
         check_version(self.master)
@@ -701,6 +715,13 @@ class TestHSMcertFixReplica(BaseHSMTest):
             nameservers='master' if cls.master_with_dns else None,
             extra_args=('--token-password', cls.token_password,)
         )
+
+    @classmethod
+    def uninstall(cls, mh):
+        # As the fixture expire_cert_critical already uninstalls the servers,
+        # skip this step in uninstall
+        check_version(cls.master)
+        delete_hsm_token([cls.master] + cls.replicas, cls.token_name)
 
     @pytest.fixture
     def expire_certs(self):


### PR DESCRIPTION
The class TestHSMcertFix is using a fixture moving the date in the future
in order to expire certificates. The fixture also uninstalls the server
before moving the date back.

The class needs to override the uninstall method to avoid calling
twice ipa-server-install --uninstall, and perform only token cleanup.

Same for TestHSMcertFixKRA and TestHSMcertFixReplica.

Fixes: https://codeberg.org/freeipa/freeipa/issues/10021